### PR TITLE
Event log window size requested it's too big for small screens

### DIFF
--- a/SparkleShare/SparkleLog.cs
+++ b/SparkleShare/SparkleLog.cs
@@ -45,7 +45,7 @@ namespace SparkleShare {
 			LocalPath = path;
 			
 			string name = System.IO.Path.GetFileName (LocalPath);
-			SetSizeRequest (480, 640);
+			SetDefaultSize (480, 640);
 
 	 		SetPosition (WindowPosition.Center);
 			BorderWidth = 0;


### PR DESCRIPTION
Hi SparkleShare folks!

I propose a little change: setting default size for the event log window better than forcing a minimun height/width via SetSizeRequest method. The reason: in small screens (like my 8.9'' netbook) it's such a long event log window that even the buttons below keep hidden, and shrinking the window isn't allowed because of the SetSizeRequest method.

This is also recommend at mono gtk-sharp SetSizeRequest-method reference:

"You can use this method to force a widget to be either larger or smaller than it normally would be. In most cases, Window.SetDefaultSize is a better choice for toplevel windows than this method; setting the default size will still allow users to shrink the window. Setting the size request will force them to leave the window at least as large as the size request."

I hope you take this into account.
Yours sincerely.
