### PR TITLE
Fix SSH agent in start script

### DIFF
--- a/SparkleShare/sparkleshare.in
+++ b/SparkleShare/sparkleshare.in
@@ -16,7 +16,7 @@ start() {
 
   echo -n "Starting SparkleShare... "
   mkdir -p /tmp/sparkleshare/
-  if [ -n "$SSH_AUTH_PID" ]; then
+  if [ -n "$SSH_AGENT_PID" ]; then
     mono "@expanded_libdir@/@PACKAGE@/SparkleShare.exe" $2 &
   else
     ssh-agent mono "@expanded_libdir@/@PACKAGE@/SparkleShare.exe" $2 &


### PR DESCRIPTION
The start script is looking at the wrong environment variable when deciding whether to start an ssh-agent.  This commit fixes it.
