### PR TITLE
Fixing issue #224, where the Recent Events window is refreshed & jumps to the top on every link click

### DIFF
--- a/SparkleShare/SparkleEventLog.cs
+++ b/SparkleShare/SparkleEventLog.cs
@@ -92,7 +92,8 @@ namespace SparkleShare {
                             process.StartInfo.Arguments = args.Request.Uri.Replace (" ", "\\ "); // Escape space-characters
                             process.Start ();
 
-                            UpdateEvents ();
+                            // Don't follow HREFs (as this would cause a page refresh)
+                            args.RetVal = 1;
                         }
                     };
 


### PR DESCRIPTION
fix history "Recent Events" jump-to-top refresh by blocking WebKit from loading URIs directly
