### PR TITLE
Use correct package names for Fedora 14

### DIFF
--- a/README
+++ b/README
@@ -78,8 +78,8 @@ On Fedora:
 
    $ sudo yum install gtk-sharp2-devel mono-core mono-devel monodevelop \
      ndesk-dbus-devel ndesk-dbus-glib-devel nautilus-python-devel nant \
-     notify-sharp-devel webkit-gtk-devel webkit-sharp-devel webkitgtk-devel \
-     libtool intltool
+     notify-sharp-devel webkit-sharp-devel webkitgtk-devel libtool intltool \
+     gnome-doc-utils
 
 
 You can build and install SparkleShare like this:


### PR DESCRIPTION
There is no package webkit-gtk-devel in Fedora and the correct package
name ('webkitgtk-devel') is already listed, so remove the incorrect one.
Also add gnome-doc-utils package to enable user help.
