### PR TITLE
(OSX) Run in background as a menu bar application

### DIFF
--- a/SparkleShare/Mac/Info.plist
+++ b/SparkleShare/Mac/Info.plist
@@ -16,5 +16,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSUIElement</key>
+	<string>1</string>
 </dict>
 </plist>


### PR DESCRIPTION
My personal preference is to have SparkleShare running in the background with a presence in the menu bar only- no icon in the Dock or when switching applications.  Since the application currently doesn't leverage the window or menu bar, I thought this might be the intention anyway.

Adding NSUIElement = "1" to the application Info.plist (the submitted change) makes an application behave this way on OSX.

Ping me with any questions.
