### PR TITLE
Enhance user's privacy

### DIFF
--- a/SparkleLib/SparkleListenerIrc.cs
+++ b/SparkleLib/SparkleListenerIrc.cs
@@ -97,6 +97,7 @@ namespace SparkleLib {
                         foreach (string channel in base.channels) {
                             SparkleHelpers.DebugInfo ("ListenerIrc", "Joining channel " + channel);
                             this.client.RfcJoin (channel);
+                            this.client.RfcMode (channel, "+s");
                         }
 
                         // List to the channel, this blocks the thread
@@ -124,6 +125,7 @@ namespace SparkleLib {
                 if (IsConnected) {
                     SparkleHelpers.DebugInfo ("ListenerIrc", "Joining channel " + channel);
                     this.client.RfcJoin (channel);
+                    this.client.RfcMode (channel, "+s");
                 }
             }
         }


### PR DESCRIPTION
Please pull this branch to enhance the privacy of the user. As the IRC server is public people can obtain information from it. Even though the channel name is a hash it is still an information leak.

Even better would be if the IRC server would cloak the hostmask of the user, but this is not fixable from the IRC client side, but needs to be done on the IRC server side.
