### PR TITLE
Making use the IRC more safe

### DIFF
--- a/SparkleLib/SparkleListenerBase.cs
+++ b/SparkleLib/SparkleListenerBase.cs
@@ -44,14 +44,6 @@ namespace SparkleLib {
             string uri = SparkleConfig.DefaultConfig.GetFolderOptionalAttribute (
                 folder_name, "announcements_url");
 
-            // Key to turn the channel access more safely.
-            string key = SparkleConfig.DefaultConfig.GetFolderOptionalAttribute (
-                folder_name, "key");
-           
-            // Identifier to define access in IRC channel when no key is defined
-            string dangerous_access = SparkleConfig.DefaultConfig.GetFolderOptionalAttribute (
-                folder_name, "dangerous_access");
-
             if (uri == null) {
                 // This is SparkleShare's centralized notification service.
                 // Don't worry, we only use this server as a backup if you
@@ -59,13 +51,6 @@ namespace SparkleLib {
                 // we don't store any personal information ever
 
                 uri = "irc://204.62.14.135/";
-            }
-
-            // This action ensures that the Sparkleshare function normally when the key is not defined.
-            // It is recommended that the user asked a question to see whether or not to allow access
-            // to the channel without a key.
-            if (dangerous_access == null) {
-              dangerous_access = "yes";
             }
 
             Uri announce_uri = new Uri (uri);
@@ -89,10 +74,10 @@ namespace SparkleLib {
                 listeners.Add (new SparkleListenerTcp (announce_uri, folder_identifier));
                 break;
             case "irc":
-                listeners.Add (new SparkleListenerIrc (announce_uri, folder_identifier, key, dangerous_access));
+                listeners.Add (new SparkleListenerIrc (announce_uri, folder_identifier));
                 break;
             default:
-                listeners.Add (new SparkleListenerIrc (announce_uri, folder_identifier, key, dangerous_access));
+                listeners.Add (new SparkleListenerIrc (announce_uri, folder_identifier));
                 break;
             }
             


### PR DESCRIPTION
Implemented rules was to make use of the IRC protocol safer. 
From a study, I realized that it is possible to an external agent Sparkleshare access the server and the IRC channels of projects, an attacker can perform a DoS on the clients. 

One way to avoid this type of attack is making the invisible channel, which has already been done in a commit. 
Another solution is to use keys to access the channel. I've implemented this using the configuration file Sparkleshare. 

To set a password, just add a new element node in the project: 
<key> 123 </ key> 

Thus is set the password, but this configuration should be applied to all users of the project, if a user does not set, it will not be able to access the IRC channel. 
If all users choose not to define the key, then the channel does not use keys to access. The key is defined on the server by the first user to connect to IRC server. 

Also created a configuration that allows the user to allow or disallow access to channels that has no password set, as if an alert that the channel is not secure and if he wants to continue or not. 

I also use the configuration file to determine whether or not enough access to add the element node in the project: 
<dangerous_access> yes </ dangerous_access> 
or 
<dangerous_access> in </ dangerous_access> 

If you do not configure this setting will be considered that the access is allowed, this way normal use of Sparkleshare is not changed.
