### PR TITLE
Add missing shebang to nautilus extensions

### DIFF
--- a/SparkleShare/Nautilus/sparkleshare-nautilus-extension.py.in
+++ b/SparkleShare/Nautilus/sparkleshare-nautilus-extension.py.in
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 #   SparkleShare, an instant update workflow to Git.
 #   Copyright (C) 2010  Hylke Bons <hylkebons@gmail.com>
 #

--- a/SparkleShare/Nautilus/sparkleshare-nautilus3-extension.py.in
+++ b/SparkleShare/Nautilus/sparkleshare-nautilus3-extension.py.in
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 #   SparkleShare, an instant update workflow to Git.
 #   Copyright (C) 2010  Hylke Bons <hylkebons@gmail.com>
 #


### PR DESCRIPTION
This is the remaining patch from the Debian package.
