### PR TITLE
Gut back-end (Simple API for external tools)

### DIFF
--- a/SparkleLib/Gut/SparkleFetcherGut.cs
+++ b/SparkleLib/Gut/SparkleFetcherGut.cs
@@ -1,0 +1,140 @@
+//   A gutted-out interface from sparkleshare to any random executable,
+//   designed to make sparkleshare back-ends incredibly easy to develop
+//   in any language:
+//   Copyright (C) 2012  Shish <shish@shishnet.org>
+//
+//   Based on the default Git back-end:
+//   Copyright (C) 2010  Hylke Bons <hylkebons@gmail.com>
+//
+//   This program is free software: you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License as published by
+//   the Free Software Foundation, either version 3 of the License, or
+//   (at your option) any later version.
+//
+//   This program is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//   GNU General Public License for more details.
+//
+//   You should have received a copy of the GNU General Public License
+//   along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+using System;
+using System.IO;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+namespace SparkleLib {
+
+    // Sets up a fetcher that can get remote folders
+    public class SparkleFetcherGut : SparkleFetcherBase {
+
+        private SparkleGut gut;
+
+
+        public SparkleFetcherGut (string server, string remote_path, string target_folder) :
+            base (server, remote_path, target_folder)
+        {
+            if (server.EndsWith ("/"))
+                server = server.Substring (0, server.Length - 1);
+
+            // FIXME: Adding these lines makes the fetcher fail
+            // if (remote_path.EndsWith ("/"))
+            //     remote_path = remote_path.Substring (0, remote_path.Length - 1);
+
+            if (!remote_path.StartsWith ("/"))
+                remote_path = "/" + remote_path;
+
+
+            Uri uri;
+
+            try {
+                uri = new Uri (server + remote_path);
+            } catch (UriFormatException) {
+                uri = new Uri ("rsync+ssh://" + server + remote_path);
+            }
+
+            TargetFolder = target_folder;
+            RemoteUrl    = uri.ToString ();
+        }
+
+
+        public override bool Fetch ()
+        {
+            // place settings into the folder
+            this.gut = new SparkleGut (SparkleConfig.DefaultConfig.TmpPath,
+                "configure \"" + TargetFolder + "\" --url=\"" + RemoteUrl + "\"" +
+                " --user=\"" + SparkleConfig.DefaultConfig.User.Name +
+                " <" + SparkleConfig.DefaultConfig.User.Email + ">\"");
+            this.gut.Start ();
+            this.gut.StandardOutput.ReadToEnd ().TrimEnd ();
+            this.gut.WaitForExit ();
+
+            // use the previously-set settings to fetch the base data
+            this.gut = new SparkleGut (TargetFolder, "fetch");
+            
+            this.gut.StartInfo.RedirectStandardError = true;
+            this.gut.Start ();
+
+            double percentage = 1.0;
+            Regex progress_regex = new Regex (@"([0-9]+)%", RegexOptions.Compiled);
+
+            DateTime last_change     = DateTime.Now;
+            TimeSpan change_interval = new TimeSpan (0, 0, 0, 1);
+
+            while (!this.gut.StandardError.EndOfStream) {
+                string line = this.gut.StandardError.ReadLine ();
+                Match match = progress_regex.Match (line);
+                
+                double number = 0.0;
+                if (match.Success) {
+                    number = double.Parse (match.Groups [1].Value);
+                }
+                
+                if (number >= percentage) {
+                    percentage = number;
+
+                    if (DateTime.Compare (last_change, DateTime.Now.Subtract (change_interval)) < 0) {
+                        base.OnProgressChanged (percentage);
+                        last_change = DateTime.Now;
+                    }
+                }
+            }
+            
+            this.gut.WaitForExit ();
+            SparkleHelpers.DebugInfo ("Gut", "Exit code " + this.gut.ExitCode.ToString ());
+
+            while (percentage < 100) {
+                percentage += 25;
+
+                if (percentage >= 100)
+                    break;
+
+                base.OnProgressChanged (percentage);
+                Thread.Sleep (750);
+            }
+
+            base.OnProgressChanged (100);
+            Thread.Sleep (1000);
+
+            if (this.gut.ExitCode != 0) {
+                return false;
+            } else {
+                return true;
+            }
+        }
+
+
+        public override void Stop ()
+        {
+            if (this.gut != null && !this.gut.HasExited) {
+                this.gut.Kill ();
+                this.gut.Dispose ();
+            }
+
+            Dispose ();
+        }
+    }
+}

--- a/SparkleLib/Gut/SparkleGut.cs
+++ b/SparkleLib/Gut/SparkleGut.cs
@@ -1,0 +1,81 @@
+//   A gutted-out interface from sparkleshare to any random executable,
+//   designed to make sparkleshare back-ends incredibly easy to develop
+//   in any language:
+//   Copyright (C) 2012  Shish <shish@shishnet.org>
+//
+//   Based on the default Git back-end:
+//   Copyright (C) 2010  Hylke Bons <hylkebons@gmail.com>
+//
+//   This program is free software: you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License as published by
+//   the Free Software Foundation, either version 3 of the License, or
+//   (at your option) any later version.
+//
+//   This program is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//   GNU General Public License for more details.
+//
+//   You should have received a copy of the GNU General Public License
+//   along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+using System;
+using System.IO;
+using System.Diagnostics;
+
+namespace SparkleLib {
+
+    public class SparkleGut : Process {
+
+        public static string Path     = null;
+
+
+        public SparkleGut (string path, string args) : base ()
+        {
+            Path = LocateGut ();
+
+            EnableRaisingEvents              = true;
+            StartInfo.FileName               = Path;
+            StartInfo.RedirectStandardOutput = true;
+            StartInfo.UseShellExecute        = false;
+            StartInfo.WorkingDirectory       = path;
+            StartInfo.CreateNoWindow         = true;
+			StartInfo.Arguments              = args;
+        }
+
+
+        new public void Start ()
+        {
+            SparkleHelpers.DebugInfo ("Cmd", "gut " + StartInfo.Arguments);
+
+            try {
+                base.Start ();
+
+            } catch (Exception e) {
+                SparkleHelpers.DebugInfo ("Cmd", "There's a problem running Gut: " + e.Message);
+                Environment.Exit (-1);
+            }
+        }
+
+
+        private string LocateGut ()
+        {
+            if (!string.IsNullOrEmpty (Path))
+                return Path;
+
+            string [] possible_gut_paths = new string [] {
+                "/usr/bin/gut",
+                "/usr/local/bin/gut",
+                "/opt/local/bin/gut",
+                "/usr/local/gut/bin/gut"
+            };
+
+            foreach (string path in possible_gut_paths)
+                if (File.Exists (path))
+                    return path;
+
+            return "gut";
+        }
+    }
+}

--- a/SparkleLib/Gut/SparkleRepoGut.cs
+++ b/SparkleLib/Gut/SparkleRepoGut.cs
@@ -1,0 +1,299 @@
+//   A gutted-out interface from sparkleshare to any random executable,
+//   designed to make sparkleshare back-ends incredibly easy to develop
+//   in any language:
+//   Copyright (C) 2012  Shish <shish@shishnet.org>
+//
+//   Based on the default Git back-end:
+//   Copyright (C) 2010  Hylke Bons <hylkebons@gmail.com>
+//
+//   This program is free software: you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License as published by
+//   the Free Software Foundation, either version 3 of the License, or
+//   (at your option) any later version.
+//
+//   This program is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//   GNU General Public License for more details.
+//
+//   You should have received a copy of the GNU General Public License
+//   along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Security.Cryptography;
+
+namespace SparkleLib {
+
+    public class SparkleRepoGut : SparkleRepoBase {
+
+        public SparkleRepoGut (string path) : base (path)
+        {
+        }
+
+
+        public override string Identifier {
+            get {
+                SparkleGut gut = new SparkleGut (LocalPath, "identifier");
+                gut.Start ();
+                string output = gut.StandardOutput.ReadToEnd ().TrimEnd ();
+                gut.WaitForExit ();
+                return output;
+            }
+        }
+
+
+        public override List<string> ExcludePaths {
+            get {
+                List<string> rules = new List<string> ();
+                rules.Add (".gut");
+
+                return rules;
+            }
+        }
+
+
+        public override double Size {
+            get {
+                SparkleGut gut = new SparkleGut (LocalPath, "size");
+                gut.Start ();
+                string output = gut.StandardOutput.ReadToEnd ().TrimEnd ();
+                gut.WaitForExit ();
+                return double.Parse(output);
+            }
+        }
+
+
+        public override double HistorySize {
+            get {
+                SparkleGut gut = new SparkleGut (LocalPath, "history-size");
+                gut.Start ();
+                string output = gut.StandardOutput.ReadToEnd ().TrimEnd ();
+                gut.WaitForExit ();
+                return double.Parse(output);
+            }
+        }
+
+
+        public override string [] UnsyncedFilePaths {
+            get {
+                SparkleGut gut = new SparkleGut (LocalPath, "unsynced-file-paths");
+                gut.Start ();
+                string output = gut.StandardOutput.ReadToEnd ().TrimEnd ();
+                gut.WaitForExit ();
+                return output.Split ("\n".ToCharArray ());
+            }
+        }
+
+
+        public override string CurrentRevision {
+            get {
+                SparkleGut gut = new SparkleGut (LocalPath, "current-revision");
+                gut.Start ();
+                string output = gut.StandardOutput.ReadToEnd ().TrimEnd ();
+                gut.WaitForExit ();
+                return output;
+            }
+        }
+
+
+        public override bool HasRemoteChanges
+        {
+            get {
+                SparkleGut gut = new SparkleGut (LocalPath, "has-remote-changes");
+                gut.Start ();
+                string output = gut.StandardOutput.ReadToEnd ().TrimEnd ();
+                gut.WaitForExit ();
+                return (output.Equals("true"));
+            }
+        }
+
+
+        public override bool SyncUp ()
+        {
+            SparkleGut gut = new SparkleGut (LocalPath, "sync-up");
+            gut.StartInfo.RedirectStandardError = true;
+            gut.Start ();
+
+            double percentage = 1.0;
+            Regex progress_regex = new Regex (@"([0-9]+)%", RegexOptions.Compiled);
+            Regex speed_regex = new Regex (@"([0-9]+[KMG]?B/s)", RegexOptions.Compiled);
+            while (!gut.StandardError.EndOfStream) {
+                string line   = gut.StandardError.ReadLine ();
+                Match progress_match = progress_regex.Match (line);
+                Match speed_match    = speed_regex.Match (line);
+                string speed  = "";
+                double number = 0.0;
+
+                if (progress_match.Success) {
+                    number = double.Parse (progress_match.Groups [1].Value);
+                }
+
+                if (speed_match.Success) {
+                    speed = speed_match.Groups [1].Value;
+                }
+
+                if (number >= percentage) {
+                    percentage = number;
+                    base.OnProgressChanged (percentage, speed);
+                }
+            }
+
+            string output = gut.StandardOutput.ReadToEnd ().TrimEnd ();
+            gut.WaitForExit ();
+            return (output.Equals("true"));
+        }
+
+
+        public override bool SyncDown ()
+        {
+            SparkleGut gut = new SparkleGut (LocalPath, "sync-down");
+            gut.StartInfo.RedirectStandardError = true;
+            gut.Start ();
+
+            double percentage = 1.0;
+            Regex progress_regex = new Regex (@"([0-9]+)%", RegexOptions.Compiled);
+            Regex speed_regex = new Regex (@"([0-9]+[KMG]?B/s)", RegexOptions.Compiled);
+            while (!gut.StandardError.EndOfStream) {
+                string line   = gut.StandardError.ReadLine ();
+                Match progress_match = progress_regex.Match (line);
+                Match speed_match    = speed_regex.Match (line);
+                string speed  = "";
+                double number = 0.0;
+
+                if (progress_match.Success) {
+                    number = double.Parse (progress_match.Groups [1].Value);
+                }
+
+                if (speed_match.Success) {
+                    speed = speed_match.Groups [1].Value;
+                }
+
+                if (number >= percentage) {
+                    percentage = number;
+                    base.OnProgressChanged (percentage, speed);
+                }
+            }
+
+            string output = gut.StandardOutput.ReadToEnd ().TrimEnd ();
+            gut.WaitForExit ();
+            return (output.Equals("true"));
+        }
+
+
+        public override bool HasLocalChanges {
+            get {
+                SparkleGut gut = new SparkleGut (LocalPath, "has-local-changes");
+                gut.Start ();
+                string output = gut.StandardOutput.ReadToEnd ().TrimEnd ();
+                gut.WaitForExit ();
+                return (output.Equals("true"));
+            }
+        }
+
+
+        public override bool HasUnsyncedChanges {
+            get {
+                string unsynced_file_path = SparkleHelpers.CombineMore (LocalPath,
+                    ".gut", "has_unsynced_changes");
+
+                return File.Exists (unsynced_file_path);
+            }
+
+            set {
+                string unsynced_file_path = SparkleHelpers.CombineMore (LocalPath,
+                    ".gut", "has_unsynced_changes");
+
+                if (value) {
+                    if (!File.Exists (unsynced_file_path))
+                        File.Create (unsynced_file_path).Close ();
+
+                } else {
+                    File.Delete (unsynced_file_path);
+                }
+            }
+        }
+
+
+        // Returns a list of the latest change sets
+        public override List <SparkleChangeSet> GetChangeSets (int count)
+        {
+            if (count < 1)
+                count = 30;
+
+            List <SparkleChangeSet> change_sets = new List <SparkleChangeSet> ();
+
+            // Console.InputEncoding  = System.Text.Encoding.Unicode;
+            Console.OutputEncoding = System.Text.Encoding.Unicode;
+
+            SparkleGut gut_log = new SparkleGut (LocalPath, "get-change-sets --count=" + count);
+            gut_log.Start ();
+
+            // Reading the standard output HAS to go before
+            // WaitForExit, or it will hang forever on output > 4096 bytes
+            string output = gut_log.StandardOutput.ReadToEnd ();
+            string [] lines = output.Split ("\n".ToCharArray ());
+            gut_log.WaitForExit ();
+
+
+            SparkleChangeSet change_set = null;
+            foreach (string line in lines) {
+                if (line.StartsWith ("revision")) {
+                    change_set = new SparkleChangeSet ();
+                    change_set.Folder = Name;
+                    change_set.Url = Url;
+                    change_sets.Add (change_set);
+                }
+                if(change_set == null)
+                    continue;
+
+                string[] kv = line.Split (":".ToCharArray (), 2);
+                if(kv.Length != 2)
+                    continue;
+
+                string key = kv[0];
+                string val = kv[1];
+
+                if(key.Equals("revision")) {
+                    change_set.Revision = val;
+                }
+                if(key.Equals("user")) {
+                    Regex regex = new Regex (@"(.+) <(.+)>");
+                    Match match = regex.Match (val);
+                    change_set.User = new SparkleUser (match.Groups [1].Value, match.Groups [2].Value);
+                }
+                if(key.Equals("magical")) {
+                    change_set.IsMagical = val.Equals("true");
+                }
+                if(key.Equals("timestamp")) {
+                    Regex regex = new Regex (@"([0-9]{4})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2}):([0-9]{2}) (.[0-9]{4})");
+                    Match match = regex.Match (val);
+                    change_set.Timestamp = new DateTime (int.Parse (match.Groups [1].Value),
+                        int.Parse (match.Groups [2].Value), int.Parse (match.Groups [3].Value),
+                        int.Parse (match.Groups [4].Value), int.Parse (match.Groups [5].Value),
+                        int.Parse (match.Groups [6].Value));
+                    string time_zone     = match.Groups [7].Value;
+                    int our_offset       = TimeZone.CurrentTimeZone.GetUtcOffset(DateTime.Now).Hours;
+                    int their_offset     = int.Parse (time_zone.Substring (0, 3));
+                    change_set.Timestamp = change_set.Timestamp.AddHours (their_offset * -1);
+                    change_set.Timestamp = change_set.Timestamp.AddHours (our_offset);
+                }
+                if(key.Equals("added")) {
+                    change_set.Added.Add(val);
+                }
+                if(key.Equals("edited")) {
+                    change_set.Edited.Add(val);
+                }
+                if(key.Equals("deleted")) {
+                    change_set.Deleted.Add(val);
+                }
+            }
+
+            return change_sets;
+        }
+
+    }
+}

--- a/SparkleLib/Makefile.am
+++ b/SparkleLib/Makefile.am
@@ -6,6 +6,9 @@ SOURCES =  \
 	Git/SparkleFetcherGit.cs \
 	Git/SparkleGit.cs \
 	Git/SparkleRepoGit.cs \
+	Gut/SparkleFetcherGut.cs \
+	Gut/SparkleGut.cs \
+	Gut/SparkleRepoGut.cs \
 	SparkleAnnouncement.cs \
 	SparkleBackend.cs \
 	SparkleChangeSet.cs \


### PR DESCRIPTION
I don't know C# all that well, but I can develop very fast using python - Since I wanted to contribute to sparkleshare with the minimum of fuss, my first idea was to write a new back-end that basically maps the SparkleShare API to a command line. This is it.

Philosophy and protocol notes are here: https://github.com/shish/guts/blob/master/gut.rst

The only thing that is slightly different to the Git API is that rarely-changing parameters (eg, the repository URL and the user's ID) are set with a "configure" command and don't need to be passed every time. This makes the back-ends much more pleasant to use as stand-alone command line tools.

My proof of concept implementation of a back-end executable is here: https://github.com/shish/guts -- it's a very simple and unoptimised sync tool, but it should suffice as a reference (although even as it is, it has some advantages over the git back-end)

So, over to you guys -- do you think allowing external scripts as back-ends is a good approach? Is the sparkleshare C# API good to use as a command-line API? Any other comments?

If the general idea is good, my next idea is to extend the plugin detection -- where currently compiled-in back-ends are detected (eg the repo "foo.git" uses "SparkleRepoGit"), I'd like to also detect external back ends (eg, if SparkleRepoGit didn't exist, sparkleshare would attempt to use the command line tool `/usr/lib/sparkleshare/backends/git`); would that be sensible?
