### PR TITLE
Adding self to AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ Contributors:
 	Philipp Gildein <rmbl@openspeak-project.org>
 	Ruben Vermeersch <rubenv@gnome.org>
 	Sandy Armstrong <sanfordarmstrong@gmail.com>
+	Shish <shish@shishnet.org>
 	Simon Pither <simon@pither.com>
 	Steven Harms <sharms@ubuntu.com>
 	Sven Mueller <thelightmaker@gmail.com>


### PR DESCRIPTION
Hopefully just having the single name that I use is OK, the use of my surname is deprecated and will be removed when I can afford the legal fees ^^;
