### PR TITLE
make sure that bin exists before copying files into it

### DIFF
--- a/SparkleShare/Windows/build.cmd
+++ b/SparkleShare/Windows/build.cmd
@@ -8,7 +8,8 @@ if not exist %msbuild% set msbuild="%WinDirNet%\v4.0.30319\msbuild.exe"
 set wixBinDir=%WIX%\bin
 
 
-copy ..\..\data\icons\sparkleshare.ico ..\..\bin
+if not exist ..\..\bin mkdir ..\..\bin
+copy ..\..\data\icons\sparkleshare.ico ..\..\bin\
 
 %msbuild% /t:Rebuild /p:Configuration=Release /p:Platform="AnyCPU"   %~dp0\tools\gettext-cs-utils\Gettext.CsUtils\Core\Gettext.Cs\Gettext.Cs.csproj
 %msbuild% /t:Rebuild /p:Configuration=Release /p:Platform="Any CPU" %~dp0\SparkleShare.sln


### PR DESCRIPTION
Windows users who haven't read the README, or who have done `git clean -fdx`, will receive a weird build error because sparkleshare.ico is not a folder. This patch creates the bin folder if it doesn't exist and then copies sparkleshare.ico _into_ it.
