### PR TITLE
Fixes issues with building on Windows when the path contains spaces

### DIFF
--- a/SparkleLib/windows/SparkleLib.Git.csproj
+++ b/SparkleLib/windows/SparkleLib.Git.csproj
@@ -86,6 +86,6 @@
   </Target>
   -->
   <PropertyGroup>
-    <PreBuildEvent>$(ProjectDir)transform_tt.cmd</PreBuildEvent>
+    <PreBuildEvent>"$(ProjectDir)transform_tt.cmd"</PreBuildEvent>
   </PropertyGroup>
 </Project>

--- a/SparkleLib/windows/SparkleLib.csproj
+++ b/SparkleLib/windows/SparkleLib.csproj
@@ -163,6 +163,6 @@
     <VisualStudio />
   </ProjectExtensions>
   <PropertyGroup>
-    <PreBuildEvent>$(ProjectDir)transform_tt.cmd</PreBuildEvent>
+    <PreBuildEvent>"$(ProjectDir)transform_tt.cmd"</PreBuildEvent>
   </PropertyGroup>
 </Project>

--- a/SparkleShare/Windows/SparkleShare.csproj
+++ b/SparkleShare/Windows/SparkleShare.csproj
@@ -177,7 +177,7 @@
     </None>
   </ItemGroup>
   <PropertyGroup>
-    <PreBuildEvent>$(ProjectDir)transform_tt.cmd</PreBuildEvent>
+    <PreBuildEvent>"$(ProjectDir)transform_tt.cmd"</PreBuildEvent>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\..\data\about.png">

--- a/SparkleShare/Windows/build.cmd
+++ b/SparkleShare/Windows/build.cmd
@@ -11,8 +11,8 @@ set wixBinDir=%WIX%\bin
 if not exist ..\..\bin mkdir ..\..\bin
 copy ..\..\data\icons\sparkleshare.ico ..\..\bin\
 
-%msbuild% /t:Rebuild /p:Configuration=Release /p:Platform="AnyCPU"   %~dp0\tools\gettext-cs-utils\Gettext.CsUtils\Core\Gettext.Cs\Gettext.Cs.csproj
-%msbuild% /t:Rebuild /p:Configuration=Release /p:Platform="Any CPU" %~dp0\SparkleShare.sln
+%msbuild% /t:Rebuild /p:Configuration=Release /p:Platform="AnyCPU"   "%~dp0\tools\gettext-cs-utils\Gettext.CsUtils\Core\Gettext.Cs\Gettext.Cs.csproj"
+%msbuild% /t:Rebuild /p:Configuration=Release /p:Platform="Any CPU" "%~dp0\SparkleShare.sln"
 
 if "%1"=="installer" (
 	if exist "%wixBinDir%" (

--- a/SparkleShare/Windows/tools/TextTemplating/build.cmd
+++ b/SparkleShare/Windows/tools/TextTemplating/build.cmd
@@ -2,4 +2,4 @@
 set WinDirNet=%WinDir%\Microsoft.NET\Framework
 set msbuild="%WinDirNet%\v4.0.30319\msbuild.exe"
 
-%msbuild% /t:Rebuild /p:Configuration=Release /p:Platform="Any CPU" %~dp0\TextTemplating.sln
+%msbuild% /t:Rebuild /p:Configuration=Release /p:Platform="Any CPU" "%~dp0\TextTemplating.sln"

--- a/SparkleShare/Windows/tools/xslt/build.cmd
+++ b/SparkleShare/Windows/tools/xslt/build.cmd
@@ -3,4 +3,4 @@ set WinDirNet=%WinDir%\Microsoft.NET\Framework
 set msbuild="%WinDirNet%\v3.5\msbuild.exe"
 if not exist %msbuild% set msbuild="%WinDirNet%\v4.0.30319\msbuild.exe"
 
-%msbuild% /t:Rebuild /p:Configuration=Release /p:Platform="Any CPU" %~dp0\xslt.sln
+%msbuild% /t:Rebuild /p:Configuration=Release /p:Platform="Any CPU" "%~dp0\xslt.sln"

--- a/data/plugins/build.cmd
+++ b/data/plugins/build.cmd
@@ -5,7 +5,7 @@ set xslt=..\..\SparkleShare\Windows\tools\xslt\bin\release\xslt.exe
 if not exist %xslt% call ..\..\SparkleShare\Windows\tools\xslt\build.cmd
 
 for %%a in (*.xml.in) do (
-  %xslt% parse_plugins.xsl %%a %%~dpna
+  %xslt% parse_plugins.xsl "%%a" "%%~dpna"
 )
 
 popd


### PR DESCRIPTION
Prior to this patch, the build process fails if the path to the root directory contains a space
