### PR TITLE
SparkleLib: Use rev-parse HEAD to determine latest commit

### DIFF
--- a/SparkleLib/Git/SparkleRepoGit.cs
+++ b/SparkleLib/Git/SparkleRepoGit.cs
@@ -142,7 +142,7 @@ namespace SparkleLib.Git {
                 if (File.Exists (rebase_apply_file))
                     File.Delete (rebase_apply_file);
 
-                SparkleGit git = new SparkleGit (LocalPath, "log -1 --format=%H");
+                SparkleGit git = new SparkleGit (LocalPath, "rev-parse HEAD");
                 git.Start ();
                 git.WaitForExit ();
 


### PR DESCRIPTION
While `git log -1 --format=%H` does show the same data, it needs to
start up the revision walking machinery just to show the latest
commit's hash. `git rev-parse HEAD` tells us this commit's hash
without doing all the extra work.

Unscientific testing shows ~10ms vs. ~5ms with warm cache. Cold cache, a spinning disc or an OS where `mmap` isn't that great should make this difference larger. It's nothing ground-breaking, but it saves us some processing on each call.
