### PR TITLE
po: remove SparkleShare/SparkleOptions.cs from the list

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -17,7 +17,6 @@ SparkleShare/Linux/SparkleAbout.cs
 SparkleShare/Linux/SparkleController.cs
 SparkleShare/SparkleControllerBase.cs
 SparkleShare/Linux/SparkleEventLog.cs
-SparkleShare/SparkleOptions.cs
 SparkleShare/Linux/SparkleSetup.cs
 SparkleShare/Linux/SparkleSetupWindow.cs
 SparkleShare/Linux/SparkleStatusIcon.cs

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,4 +1,3 @@
 MacCore/src/Options.cs
 SparkleShare/Linux/Nautilus/sparkleshare-nautilus-extension.py
 SparkleShare/Linux/Nautilus/sparkleshare-nautilus3-extension.py
-SparkleLib/SparkleOptions.cs


### PR DESCRIPTION
It was removed from the tree, but not from the i18n files
