### PR TITLE
Added support for special characters in paths

### DIFF
--- a/SparkleLib/Git/SparkleRepoGit.cs
+++ b/SparkleLib/Git/SparkleRepoGit.cs
@@ -480,7 +480,7 @@ namespace SparkleLib.Git {
 
             foreach (string line in lines) {
                 string conflicting_path = line.Substring (3);
-                conflicting_path = conflicting_path.Trim ("\"".ToCharArray ());
+                conflicting_path = this.EnsureSpecialCharacters (conflicting_path);
 
                 SparkleHelpers.DebugInfo ("Git", Name + " | Conflict type: " + line);
 


### PR DESCRIPTION
This works for me in Windows i have no idea how this will work out on linux.
Without this commit sparkleshare was crashing all the time without any real error message.
