### PR TITLE
Fix for a possible crash on file deletion while resolving conflicts

### DIFF
--- a/SparkleLib/Git/SparkleRepoGit.cs
+++ b/SparkleLib/Git/SparkleRepoGit.cs
@@ -439,9 +439,14 @@ namespace SparkleLib.Git {
             if (git.ExitCode != 0) {
                 SparkleHelpers.DebugInfo ("Git", Name + " | Conflict detected, trying to get out...");
 
-                while (HasLocalChanges)
-                    ResolveConflict ();
-
+                while (HasLocalChanges) {
+                    try {
+                        ResolveConflict();
+                    }
+                    catch (IOException e) {
+                        SparkleHelpers.DebugInfo ("Exception", e.ToString ());
+                    }
+                }
                 SparkleHelpers.DebugInfo ("Git", Name + " | Conflict resolved");
                 OnConflictResolved ();
             }


### PR DESCRIPTION
( NOTE: One file of the conflicting two will not be in history!!!)

If you follow the instructions from my comment on
https://github.com/matthid/SparkleShare/commit/985ed7c5a6a030fcaf323629c491f3ef18894323
and actually delete both files hang1 and hang2 while the breakpoint is hit, then sparkleshare will crash with a FileNotFoundException.

This commit is a possible fix for this issue.
