### PR TITLE
Fix SparkleShare.Git.csproj file references

### DIFF
--- a/SparkleLib/Git/SparkleLib.Git.csproj
+++ b/SparkleLib/Git/SparkleLib.Git.csproj
@@ -44,4 +44,9 @@
       <Name>SparkleLib</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="SparkleFetcherGit.cs" />
+    <Compile Include="SparkleGit.cs" />
+    <Compile Include="SparkleRepoGit.cs" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
There were redundant entries in SparkleShare.Git.csproj that caused warnings in VS. Patch removes those entries.
