### PR TITLE
Write invite to userprofile

### DIFF
--- a/SparkleShare/Windows/SparkleShareInviteOpener/sparkleshare-invite-opener.cs
+++ b/SparkleShare/Windows/SparkleShareInviteOpener/sparkleshare-invite-opener.cs
@@ -36,6 +36,8 @@ namespace SparkleShare {
         {
             string xml = "";
 
+            url = url.Replace("sparkleshare-unsafe:", "").Replace("sparkleshare:", "");
+
             WebClient web_client = new WebClient ();
 
             try {
@@ -48,7 +50,7 @@ namespace SparkleShare {
 
             string file_name = DateTime.UtcNow.Millisecond.ToString () + ".xml";
 
-            string home_path   = Environment.GetFolderPath (Environment.SpecialFolder.Personal);
+            string home_path   = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
             string target_path = Path.Combine (home_path, "SparkleShare", file_name);
 
             if (xml.Contains ("<sparkleshare>")) {


### PR DESCRIPTION
With the change to userprofile, the opener works. The registry keys are not created to link the sparkleshare protocol to the opener, though, so I've created a quick script using inno setup to add them. The script can be found at https://dl.dropbox.com/u/5300806/sparkle-opener.iss

Sometimes windows annoyingly seems to strip of the sparkleshare: part of the url when launching the opener (using chrome you can see exactly what gets passed, so the script explicitly adds http or https, and if windows doesn't strip off the sparkleshare protocol indicator, the opener does so (using Replace)
