### PR TITLE
Fix #936

### DIFF
--- a/SparkleLib/SparkleFetcherBase.cs
+++ b/SparkleLib/SparkleFetcherBase.cs
@@ -282,7 +282,7 @@ namespace SparkleLib {
             string host_key = process.StandardOutput.ReadToEnd ().Trim ();
             process.WaitForExit ();
 
-            if (process.ExitCode == 0 && host_key != null)
+            if (process.ExitCode == 0 && host_key != "")
                 return host_key;
             else
                 return null;


### PR DESCRIPTION
I had the same problem with my setup. The problem seemed to be that GetHostKey() returned an empty string. This was caused by ssh-keyscan returning an empty string when a non-standard port for the SSH-Server was used, which was then inserted into the known_hosts file as an empty row.
The changes I made now take the port into account and check for an empty string before returning as well.

Tested on Windows 7 (64Bit).
