### PR TITLE
Bugfix: Announcements in a folder where always considered 'already processed' as long as any announcement for that folder existed

### DIFF
--- a/SparkleLib/SparkleListenerBase.cs
+++ b/SparkleLib/SparkleListenerBase.cs
@@ -178,7 +178,7 @@ namespace SparkleLib {
 
             } else {
                 foreach (SparkleAnnouncement recent_announcement in GetRecentAnnouncements (announcement.FolderIdentifier)) {
-                    if (recent_announcement.Message.Equals (recent_announcement.Message))
+                    if (recent_announcement.Message.Equals (announcement.Message))
                         return true;
                 }
 


### PR DESCRIPTION
Caused by comparing recent_announcement.Message with itself instead of announcement.Message
