### PR TITLE
Too large commit log causes git to hang

### DIFF
--- a/SparkleLib/Git/SparkleRepoGit.cs
+++ b/SparkleLib/Git/SparkleRepoGit.cs
@@ -886,6 +886,7 @@ namespace SparkleLib.Git {
                 }
             }
 
+            git_status.StandardOutput.ReadToEnd();
             git_status.WaitForExit ();
             return message;
         }


### PR DESCRIPTION
Fix bug introduced at 1c8cffd178264bce3fae52453b2e270b8150d077 that causes the FormatCommitMessage() function to hang waiting for the git process to exit.  See the referenced commit for a line-by-line analysis.
