### PR TITLE
Do not include /.git file in calculating subdirectory size

### DIFF
--- a/SparkleLib/Git/SparkleRepoGit.cs
+++ b/SparkleLib/Git/SparkleRepoGit.cs
@@ -1069,8 +1069,12 @@ namespace SparkleLib.Git {
 
 
             try {
-                foreach (DirectoryInfo directory in parent.GetDirectories ())
-                    size += CalculateSizes (directory);
+                foreach (DirectoryInfo directory in parent.GetDirectories ()) {
+                    // Do not include LocalPath/.git file if it is a subdirectory
+                    //   This will not affect calling CalculateSizes on /.git directly
+                    if (directory.FullName != Path.Combine (LocalPath, ".git"))
+                        size += CalculateSizes (directory);
+                }
 
             } catch (Exception e) {
                 SparkleLogger.LogInfo ("Local", "Error calculating size", e);


### PR DESCRIPTION
Fixes issue #1109.

Calculating size of a folder will no longer descend into [LocalPath]/.git folder.  The calculate size function will still properly recurse if CalculateSizes is called directly on [LocalPath]/.git .
