### PR TITLE
Build problems on windows

### DIFF
--- a/SparkleShare/Windows/SparkleController.cs
+++ b/SparkleShare/Windows/SparkleController.cs
@@ -28,6 +28,7 @@ using Forms = System.Windows.Forms;
 
 using Microsoft.Win32;
 using SparkleLib;
+using System.Windows;
 
 namespace SparkleShare {
 
@@ -187,7 +188,7 @@ namespace SparkleShare {
         }
 
 
-        public override void CopyToClipBoardClicked (string text)
+        public override void CopyToClipboard (string text)
         {
             Clipboard.SetData (DataFormats.Text, text);
         }

--- a/SparkleShare/Windows/SparkleSetup.cs
+++ b/SparkleShare/Windows/SparkleSetup.cs
@@ -948,7 +948,7 @@ namespace SparkleShare {
                                 
                                 check_box.Click += delegate { Controller.StartupItemChanged (check_box.IsChecked.Value); };
                                 finish_button.Click += delegate { Controller.TutorialPageCompleted (); };
-                                copy_button.Click += delegate { Controller.CopyToClipboardClicked () };
+                                copy_button.Click += delegate { Controller.CopyToClipboardClicked(); };
     
                                 break;
                             }

--- a/SparkleShare/Windows/SparkleSetupWindow.cs
+++ b/SparkleShare/Windows/SparkleSetupWindow.cs
@@ -24,6 +24,8 @@ using System.Windows.Forms.Integration;
 using System.Windows.Media;
 using System.Windows.Shapes;
 using System.Windows.Shell;
+using System.Runtime.InteropServices;
+using System.Windows.Interop;
 
 namespace SparkleShare {
 
@@ -60,7 +62,7 @@ namespace SparkleShare {
             Closing += Close;
             SourceInitialized += delegate {
                 const int gwl_style = -16;
-                const int ws_sysmenu = 0×00080000; 
+                const int ws_sysmenu = 0x00080000; 
                 WindowInteropHelper helper = new WindowInteropHelper (this);
                 int style = GetWindowLong (helper.Handle, gwl_style);
                 SetWindowLong (helper.Handle, gwl_style, style & ~ws_sysmenu);

--- a/SparkleShare/Windows/SparkleStatusIcon.cs
+++ b/SparkleShare/Windows/SparkleStatusIcon.cs
@@ -142,8 +142,8 @@ namespace SparkleShare {
                 copy_item.Click += delegate { Controller.CopyToClipboardClicked (); };
                 
                 link_code_item.Items.Add (code_item);
-                link_code_item.Items.Add (new Separator);
-                link_code_item.Items.Add (this.copy_item);
+                link_code_item.Items.Add (new Separator());
+                link_code_item.Items.Add (copy_item);
             }
 
             CheckBox notify_check_box = new CheckBox () {


### PR DESCRIPTION
Hi,

Here is a little fix to Build on a Windows environnement.

It's essentially some copy-paste errors on your lasts commits.

The only one I'm not confiant with, is the 0*8000000 => 0x8000000 change in SparkleSetupWindow.cs.
Because it's obviously working on your environnement.

As it seems to be an encoding problem, please try with my 'x' to see if your compiler accept it.

Regards,
Gerard.

ps : By the way, thanks for this awesome tool !
