### PR TITLE
support private, secure shares with tor .onion addresses

### DIFF
--- a/SparkleLib/SparkleFetcherSSH.cs
+++ b/SparkleLib/SparkleFetcherSSH.cs
@@ -16,7 +16,12 @@ namespace SparkleLib {
 
         public override bool Fetch ()
         {
-            if (!RemoteUrl.Scheme.StartsWith ("http")) {
+            if (RemoteUrl.Host.EndsWith(".onion")) {
+                // Tor has special domain names called ".onion addresses".  They can only be
+                // resolved by using a proxy via tor. While the rest of the openssh suite
+                // fully supports proxying, ssh-keyscan does not, so we can't use it for .onion
+                SparkleLogger.LogInfo ("Auth", "using tor .onion address skipping ssh-keyscan");
+            } else if (!RemoteUrl.Scheme.StartsWith ("http")) {
                 string host_key = FetchHostKey ();
                 
                 if (string.IsNullOrEmpty (RemoteUrl.Host) || host_key == null) {


### PR DESCRIPTION
Tor has special domain names called ".onion addresses".  They can only be
resolved by using a proxy via tor. While the rest of the openssh suite
fully supports proxying, ssh-keyscan does not so it can't be used for
.onion addresses because it just barfs saying unknown host.

This patch skips the ssh-keyscan check if the domain name ends with `.onion`, which will only happen if the user if using  a tor onion address.

Supporting tor makes sparkleshare the ultimate private, secure file sharing system.  dropbox supports tor because it has manual proxy settings,
