### PR TITLE
Fix for compilation on GNU/Linux (missing System.Web reference)

### DIFF
--- a/build/build.environment.mk
+++ b/build/build.environment.mk
@@ -7,6 +7,7 @@ DIR_BIN = $(top_builddir)/bin
 
 # External libraries to link against, generated from configure
 LINK_SYSTEM = -r:System
+LINK_SYSTEM_WEB = -r:System.Web
 LINK_MONO_POSIX = -r:Mono.Posix
 
 LINK_GLIB = $(GLIBSHARP_LIBS)
@@ -24,7 +25,7 @@ REF_SPARKLELIB = $(LINK_SYSTEM) $(LINK_MONO_POSIX)
 LINK_SPARKLELIB = -r:$(DIR_BIN)/SparkleLib.dll
 LINK_SPARKLELIB_DEPS = $(REF_SPARKLELIB) $(LINK_SPARKLELIB)
 
-REF_SPARKLESHARE = $(LINK_DBUS) $(LINK_GTK) $(LINK_SPARKLELIB_DEPS) $(LINK_APP_INDICATOR)
+REF_SPARKLESHARE = $(LINK_SYSTEM_WEB) $(LINK_DBUS) $(LINK_GTK) $(LINK_SPARKLELIB_DEPS) $(LINK_APP_INDICATOR)
 
 # Cute hack to replace a space with something
 colon:= :


### PR DESCRIPTION
Without the patch, the following error appears when building :

```
Making all in build
Making all in m4
Making all in SparkleLib
  MCS   ../bin/SparkleLib.dll
warning CS2002: Source file `./Defines.cs' specified multiple times
Compilation succeeded - 1 warning(s)
Making all in SparkleLib/Git
  MCS   ../../bin/SparkleLib.Git.dll
./SparkleGit.cs(86,17): warning CS0436: The type `SparkleLib.Defines' conflicts with the imported type of same name'. Ignoring the imported type definition
/home/melchips/public/SparkleShare/bin/SparkleLib.dll (Location of the symbol related to previous warning)
Compilation succeeded - 1 warning(s)
Making all in SparkleShare
Making all in Linux
Making all in Pixmaps
Making all in icons
Making all in ubuntu-mono-dark
Making all in ubuntu-mono-light
Making all in gnome
  MCS   ../../bin/SparkleShare.exe
./../SparkleInvite.cs(69,50): error CS0103: The name `HttpUtility' does not exist in the current context
Compilation failed: 1 error(s), 0 warnings
make[3]: *** [../../bin/SparkleShare.exe] Erreur 1
make[2]: *** [all-recursive] Erreur 1
make[1]: *** [all-recursive] Erreur 1
make: *** [all-recursive] Erreur 1
```
