### PR TITLE
Hide console window when clicking invite links

### DIFF
--- a/SparkleShare/Windows/SparkleShareInviteOpener/SparkleShareInviteOpener.csproj
+++ b/SparkleShare/Windows/SparkleShareInviteOpener/SparkleShareInviteOpener.csproj
@@ -6,7 +6,7 @@
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{1DB5492D-B897-4A5E-8DD7-175EC65F52F2}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SparkleShareInviteOpener</RootNamespace>
     <AssemblyName>SparkleShareInviteOpener</AssemblyName>


### PR DESCRIPTION
Setting the project to be a windows executable rather than a console executable makes windows not display a terminal window when clicking the invite links. This gives the user a cleaner experience.
