### PR TITLE
Add missing quotes to launch script

### DIFF
--- a/SparkleShare/Linux/sparkleshare.in
+++ b/SparkleShare/Linux/sparkleshare.in
@@ -63,7 +63,7 @@ case $1 in
     ;;
   open|--open)
     invite=`date -u +%N`
-    open=`echo $2 | sed s/sparkleshare:\/\/addProject//`
+    open=`echo $2 | sed 's/sparkleshare:\/\/addProject//'`
     curl --insecure --output ~/SparkleShare/$invite.xml $open
     ;;
   *)


### PR DESCRIPTION
There is insufficient quoting in the sparkleshare launch script, such that this error is thrown when calling sparkleshare open (e.g. via an invite URL):

sed: -e expression #1, char 18: unknown option to `s'
