### PR TITLE
Add missing / to sed in "sparkleshare open"

### DIFF
--- a/SparkleShare/Linux/sparkleshare.in
+++ b/SparkleShare/Linux/sparkleshare.in
@@ -63,7 +63,7 @@ case $1 in
     ;;
   open|--open)
     invite=`date -u +%N`
-    open=`echo $2 | sed 's/sparkleshare:\/\/addProject//'`
+    open=`echo $2 | sed 's/sparkleshare:\/\/addProject\///'`
     curl --insecure --output ~/SparkleShare/$invite.xml $open
     ;;
   *)


### PR DESCRIPTION
The Invites spec says an invite should be of the form

sparkleshare://addProject/$URL

However, the current implementation doesn't purge the final / from the URL passed to curl, such that Linux clients can only use URLs of the form

sparkleshare://addProject$URL

This patch brings the Linux implementation in line with the spec
