### PR TITLE
Added functionality to show that SparkleShare is already running.

### DIFF
--- a/SparkleLib/Git/SparkleLib.Git.csproj
+++ b/SparkleLib/Git/SparkleLib.Git.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -53,7 +53,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="SparkleFetcherGit.cs" />
-    <Compile Include="SparkleGit.cs" />
+    <Compile Include="SparkleGit.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="SparkleRepoGit.cs" />
   </ItemGroup>
 </Project>

--- a/SparkleLib/SparkleLib.csproj
+++ b/SparkleLib/SparkleLib.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -38,7 +38,9 @@
     <Compile Include="SparkleListenerTcp.cs" />
     <Compile Include="SparkleBackend.cs" />
     <Compile Include="SparkleConfig.cs" />
-    <Compile Include="SparkleWatcher.cs" />
+    <Compile Include="SparkleWatcher.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="SparkleExtensions.cs" />
     <Compile Include="SparkleUser.cs" />
     <Compile Include="SparkleLogger.cs" />

--- a/SparkleShare/Program.cs
+++ b/SparkleShare/Program.cs
@@ -61,7 +61,12 @@ namespace SparkleShare {
             // Only allow one instance of SparkleShare (on Windows)
             if (!program_mutex.WaitOne (0, false)) {
                 Console.WriteLine ("SparkleShare is already running.");
-                Environment.Exit (-1);
+
+                Controller = new SparkleController ();
+                Controller.Initialize ();
+
+                UI = new SparkleUI ();
+                UI.Run ();
             }
 
             try {

--- a/SparkleShare/SparkleControllerBase.cs
+++ b/SparkleShare/SparkleControllerBase.cs
@@ -242,7 +242,7 @@ namespace SparkleShare {
             }
 
             if (FirstRun) {
-                ShowSetupWindow (PageType.Setup);
+                ShowSetupWindow(PageType.Setup);
 
                 new Thread (() => {
                     string keys_path     = Path.GetDirectoryName (SparkleConfig.DefaultConfig.FullPath);
@@ -264,6 +264,8 @@ namespace SparkleShare {
                     UpdateState ();
 
                 }).Start ();
+
+                ShowSetupWindow(PageType.AlreadyRunning);
             }
         }
 

--- a/SparkleShare/SparkleSetupController.cs
+++ b/SparkleShare/SparkleSetupController.cs
@@ -28,6 +28,7 @@ namespace SparkleShare {
     public enum PageType {
         None,
         Setup,
+        AlreadyRunning,
         Add,
         Invite,
         Syncing,

--- a/SparkleShare/Windows/CustomControls/LinkLabel.cs
+++ b/SparkleShare/Windows/CustomControls/LinkLabel.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Windows.Controls;
+
+namespace SparkleShare.CustomControls
+{
+    public class LinkLabel : Label
+    {
+        System.Windows.Input.Cursor default_cursor;
+
+        public LinkLabel ()
+        {
+            base.Foreground = System.Windows.Media.Brushes.Blue;
+        }
+
+        public string Link
+        {
+            get;
+            set;
+        }
+
+        protected override void OnMouseUp(System.Windows.Input.MouseButtonEventArgs e)
+        {
+            System.Diagnostics.Process.Start(Link.ToString());
+        }
+
+        protected override void OnMouseEnter(System.Windows.Input.MouseEventArgs e)
+        {
+            if (this.Parent != null && this.Parent is System.Windows.Controls.Canvas)
+            {
+                default_cursor = ((System.Windows.Controls.Canvas)this.Parent).Cursor;
+                ((System.Windows.Controls.Canvas)this.Parent).Cursor = System.Windows.Input.Cursors.Hand;
+            }
+        }
+
+        protected override void OnMouseLeave(System.Windows.Input.MouseEventArgs e)
+        {
+            ((System.Windows.Controls.Canvas)this.Parent).Cursor = default_cursor;
+        }
+    }
+}

--- a/SparkleShare/Windows/SparkleSetup.cs
+++ b/SparkleShare/Windows/SparkleSetup.cs
@@ -40,7 +40,6 @@ namespace SparkleShare {
     
         public SparkleSetupController Controller = new SparkleSetupController ();
         
-        
         public SparkleSetup ()
         {
             Controller.ShowWindowEvent += delegate {
@@ -154,6 +153,43 @@ namespace SparkleShare {
                         
                         break;
                     }
+
+                    case PageType.AlreadyRunning:
+                           Header      = "SparkleShare is already running!";
+                           Description = "Check out your projects.";
+                           int top = 100;
+
+                           Button okay = new Button() {
+                               Content = "Okay"
+                           };
+
+                           Buttons.Add (okay);
+                           
+                           okay.Click += delegate {
+                               Controller.PageCancelled();
+
+                               Environment.Exit(-1);
+                           };
+
+                           SparkleLib.SparkleConfig Config = SparkleLib.SparkleConfig.DefaultConfig;
+
+                           List<string> str_folders = Config.Folders;
+
+                           foreach (string str_folder in str_folders)
+                           {
+                               SparkleShare.CustomControls.LinkLabel project_label = new SparkleShare.CustomControls.LinkLabel()
+                               {
+                                   Link = Config.FoldersPath + "\\" + str_folder,
+                                   Content = str_folder
+                               };
+
+                               ContentCanvas.Children.Add(project_label);
+                               Canvas.SetLeft(project_label, 180);
+                               Canvas.SetTop(project_label, top);
+
+                               top += 20;
+                           }
+                        break;
 
                     case PageType.Invite: {
                         Header      = "You’ve received an invite!";

--- a/SparkleShare/Windows/SparkleShare.csproj
+++ b/SparkleShare/Windows/SparkleShare.csproj
@@ -41,6 +41,14 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <OutputPath>bin\Debug\</OutputPath>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
+    <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
+  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Reference Include="System" />
@@ -76,6 +84,7 @@
       <Link>SparkleStatusIconController.cs</Link>
     </Compile>
     <Compile Include="..\SparkleSetupController.cs" />
+    <Compile Include="CustomControls\LinkLabel.cs" />
     <Compile Include="SparkleShortcut.cs" />
     <Compile Include="SparkleUI.cs" />
     <Compile Include="..\SparkleAboutController.cs" />

--- a/SparkleShare/Windows/SparkleShare.sln
+++ b/SparkleShare/Windows/SparkleShare.sln
@@ -15,25 +15,34 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SparkleLib.Git", "..\..\Spa
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{009FDCD7-1D57-4202-BB6D-8477D8C6B8EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{009FDCD7-1D57-4202-BB6D-8477D8C6B8EE}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1DB5492D-B897-4A5E-8DD7-175EC65F52F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1DB5492D-B897-4A5E-8DD7-175EC65F52F2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2C914413-B31C-4362-93C7-1AE34F09112A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2C914413-B31C-4362-93C7-1AE34F09112A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{728483AA-E34B-4441-BF2C-C8BC2901E4E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{728483AA-E34B-4441-BF2C-C8BC2901E4E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{728483AA-E34B-4441-BF2C-C8BC2901E4E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{728483AA-E34B-4441-BF2C-C8BC2901E4E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1DB5492D-B897-4A5E-8DD7-175EC65F52F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1DB5492D-B897-4A5E-8DD7-175EC65F52F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1DB5492D-B897-4A5E-8DD7-175EC65F52F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1DB5492D-B897-4A5E-8DD7-175EC65F52F2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C914413-B31C-4362-93C7-1AE34F09112A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C914413-B31C-4362-93C7-1AE34F09112A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C914413-B31C-4362-93C7-1AE34F09112A}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C914413-B31C-4362-93C7-1AE34F09112A}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{009FDCD7-1D57-4202-BB6D-8477D8C6B8EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{009FDCD7-1D57-4202-BB6D-8477D8C6B8EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{009FDCD7-1D57-4202-BB6D-8477D8C6B8EE}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{009FDCD7-1D57-4202-BB6D-8477D8C6B8EE}.Release|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = SparkleShare.csproj
 		version = 
 		outputpath = bin
 		name = SparkleShare
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/SparkleShare/Windows/SparkleShareInviteOpener/SparkleShareInviteOpener.csproj
+++ b/SparkleShare/Windows/SparkleShareInviteOpener/SparkleShareInviteOpener.csproj
@@ -22,6 +22,16 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
+    <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>

--- a/SparkleShare/Windows/SparkleUI.cs
+++ b/SparkleShare/Windows/SparkleUI.cs
@@ -39,8 +39,8 @@ namespace SparkleShare {
             About      = new SparkleAbout ();
             Bubbles    = new SparkleBubbles ();
             StatusIcon = new SparkleStatusIcon ();
-            
-            Program.Controller.UIHasLoaded ();
+
+            Program.Controller.UIHasLoaded();
         }
 
         


### PR DESCRIPTION
Added functionality to display that "SparkleShare" is already running. It also displays a list of repositories on which user can click.

This is mainly added as current implementation was confusing when we try to run the EXE after initial setup. According to me, it makes this more user friendly.
