### PR TITLE
Update SparkleExtensions.cs

### DIFF
--- a/SparkleLib/SparkleExtensions.cs
+++ b/SparkleLib/SparkleExtensions.cs
@@ -26,12 +26,13 @@ namespace SparkleLib {
 
         public static string Combine (this string [] parts)
         {
-            string new_path = "";
-
+            StringBuilder new_path = new StringBuilder();
+            
             foreach (string part in parts)
-                new_path = Path.Combine (new_path, part);
-
-            return new_path;
+                new_path.Append(part + "\\"");
+                
+            new_path = new_path.Remove(new_path.Length - 1,1);
+            return new_path.ToString();
         }
 
         


### PR DESCRIPTION
Hi! Maybe you can use StringBuilder in the Combine method. Strings are inmutable, then when you reassign a new value, you are making copies of the string, and wasting some memory, maybe not much in this case, but imagine that parts have 10000 elements (maybe impossible, i know), you are going to make 10000 copies. With StringBuilder it doesn´t happend! 
Best regards! 
I hope you can use it
