### PR TITLE
Fix 'Recent Changes' dialog placement

### DIFF
--- a/SparkleShare/Linux/SparkleEventLog.cs
+++ b/SparkleShare/Linux/SparkleEventLog.cs
@@ -44,10 +44,11 @@ namespace SparkleShare {
 
         public SparkleEventLog () : base ("")
         {
-            SetSizeRequest (480, (int) (Gdk.Screen.Default.Height * 0.8));
+            Gdk.Rectangle monitor_0_rect = Gdk.Screen.Default.GetMonitorGeometry(0);
+            SetDefaultSize (480, (int) (monitor_0_rect.Height * 0.8));
 
-            int x = (int) (Gdk.Screen.Default.Width * 0.61);
-            int y = (int) (Gdk.Screen.Default.Height * 0.5 - (HeightRequest * 0.5));
+            int x = (int) (monitor_0_rect.Width * 0.61);
+            int y = (int) (monitor_0_rect.Height * 0.5 - (HeightRequest * 0.5));
             
             Move (x, y);
 


### PR DESCRIPTION
On multi-monitor setups this was messed up, especially if one monitor
is below the other. Now get dimensions of 1st monitor and place based
on those. Preserve existing (strange?) placement logic.
Use SetDefaultSize rather than SetSizeRequest to allow resizing.
