### PR TITLE
Add git to one-liners for Fedora, Debian and Ubuntu.

### DIFF
--- a/SparkleShare/Linux/README.md
+++ b/SparkleShare/Linux/README.md
@@ -32,7 +32,7 @@ You can use one of the commands listed below for the most used Linux distributio
 ```bash
 $ sudo apt-get install libappindicator0.1-cil-dev gtk-sharp2 mono-runtime mono-devel \
   monodevelop libndesk-dbus1.0-cil-dev nant libnotify-cil-dev libgtk2.0-cil-dev mono-mcs \
-  mono-gmcs libwebkit-cil-dev intltool libtool libndesk-dbus-glib1.0-cil-dev
+  mono-gmcs libwebkit-cil-dev intltool libtool libndesk-dbus-glib1.0-cil-dev git
 ```
 
 #### Fedora
@@ -40,7 +40,7 @@ $ sudo apt-get install libappindicator0.1-cil-dev gtk-sharp2 mono-runtime mono-d
 ```bash
 $ sudo yum install gtk-sharp2-devel mono-core mono-devel monodevelop ndesk-dbus-devel \
   ndesk-dbus-glib-devel nant notify-sharp-devel webkit-sharp-devel webkitgtk-devel libtool \
-  intltool desktop-file-utils
+  intltool desktop-file-utils git-core
 ```
 
 #### Debian
@@ -48,7 +48,7 @@ $ sudo yum install gtk-sharp2-devel mono-core mono-devel monodevelop ndesk-dbus-
 ```bash
 $ sudo apt-get install gtk-sharp2 mono-runtime mono-devel monodevelop libndesk-dbus1.0-cil-dev \
   nant libnotify-cil-dev libgtk2.0-cil-dev mono-mcs mono-gmcs libwebkit-cil-dev intltool libtool \
-  libndesk-dbus-glib1.0-cil-dev desktop-file-utils
+  libndesk-dbus-glib1.0-cil-dev desktop-file-utils git
 ```
 
 #### openSUSE


### PR DESCRIPTION
openSUSE has git in the default distribution so I left that. This is to resolve https://github.com/hbons/SparkleShare/issues/1388
