### PR TITLE
build: distribute both license files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,8 @@ DIST_SUBDIRS = $(basedirs) SparkleShare
 EXTRA_DIST = \
 	News.txt \
         README.md \
-	legal/License.txt \
+	legal/License_for_SparkleShare.txt \
+	legal/License_for_SparkleLib.txt \
 	legal/Trademark.txt \
 	legal/Authors.txt \
 	SparkleShare/Linux/sparkleshare.appdata.xml


### PR DESCRIPTION
The switch to two differences licenses made two license files where
there used to be one. Distribute both with the dist target.
