### PR TITLE
Ensure that "this.menu.Delegate" is NOT called fron non mainthread

### DIFF
--- a/SparkleShare/Mac/SparkleStatusIcon.cs
+++ b/SparkleShare/Mac/SparkleStatusIcon.cs
@@ -30,6 +30,7 @@ namespace SparkleShare {
 
         private NSStatusItem status_item = NSStatusBar.SystemStatusBar.CreateStatusItem (28);
         private NSMenu menu, submenu, link_code_submenu;
+        private SparkleMenuDelegate menuDelegate;
 
         private NSMenuItem state_item, folder_item, add_item, about_item, recent_events_item, quit_item,
             code_item, copy_item, link_code_item;
@@ -98,9 +99,8 @@ namespace SparkleShare {
             };
 
             Controller.UpdateMenuEvent += delegate {
-                while ((this.menu.Delegate as SparkleMenuDelegate).MenuIsOpen)
+                while (this.menuDelegate.MenuIsOpen)
                     System.Threading.Thread.Sleep (100);
-
                 Program.Controller.Invoke (() => CreateMenu ());
             };
 
@@ -232,7 +232,8 @@ namespace SparkleShare {
             this.menu.AddItem (NSMenuItem.SeparatorItem);
             this.menu.AddItem (this.quit_item);
 
-            this.menu.Delegate    = new SparkleMenuDelegate ();
+            this.menuDelegate = new SparkleMenuDelegate ();
+            this.menu.Delegate    = this.menuDelegate;
             this.status_item.Menu = this.menu;
         }
     


### PR DESCRIPTION
This was a reason for SparkleShare to crash under OSX

I know that the whole menu updating mechanisms should be resorted… 
So far, this is just a hack to prevent the crash.
