### PR TITLE
catch unhandled exceptions

### DIFF
--- a/SparkleShare/Program.cs
+++ b/SparkleShare/Program.cs
@@ -88,11 +88,11 @@ namespace SparkleShare {
             #endif
         }
 
-        static void OnUnhandledException(object sender, UnhandledExceptionEventArgs exceptionArgs)
+        static void OnUnhandledException(object sender, UnhandledExceptionEventArgs exception_args)
         {
             try
             {
-                var e = (Exception)exceptionArgs.ExceptionObject;
+                var e = (Exception)exception_args.ExceptionObject;
                 SparkleLogger.WriteCrashReport(e);
             }
             finally


### PR DESCRIPTION
and create a proper crash report.

This fix takes care of unhandled exceptions in background threads
The former solution (try catch around UI.Run) did only take care of
unhandled exceptions in the main / UI thread.
