### PR TITLE
Fix for #1560

### DIFF
--- a/SparkleShare/Mac/SparkleController.cs
+++ b/SparkleShare/Mac/SparkleController.cs
@@ -62,16 +62,16 @@ namespace SparkleShare {
             this.watcher.Changed += OnFilesChanged;
         }
 
-        private void OnFilesChanged(List<string> changedFilesInBasedir)
+        private void OnFilesChanged(List<string> changed_files_in_basedir)
         {
-            Dictionary<SparkleRepoBase, List<string>> changeDict = new Dictionary<SparkleRepoBase, List<string>> ();
+            Dictionary<SparkleRepoBase, List<string>> change_dict = new Dictionary<SparkleRepoBase, List<string>> ();
 
-            foreach (string file in changedFilesInBasedir) {
+            foreach (string file in changed_files_in_basedir) {
                 string repo_name;
-                int pathSepIndex = file.IndexOf (Path.DirectorySeparatorChar);
+                int path_sep_index = file.IndexOf (Path.DirectorySeparatorChar);
 
-                if (pathSepIndex >= 0)
-                    repo_name = file.Substring (0, pathSepIndex);
+                if (path_sep_index >= 0)
+                    repo_name = file.Substring (0, path_sep_index);
                 else
                     repo_name = file;
 
@@ -83,18 +83,18 @@ namespace SparkleShare {
 
                 List<string> changes;
 
-                if (changeDict.ContainsKey (repo))
-                    changes = changeDict [repo];
+                if (change_dict.ContainsKey (repo))
+                    changes = change_dict [repo];
                 else {
                     changes = new List<string> ();
-                    changeDict.Add (repo, changes);
+                    change_dict.Add (repo, changes);
                 }
 
                 changes.Add (Path.Combine (SparkleConfig.DefaultConfig.FoldersPath, file));
             }
 
-            foreach (SparkleRepoBase repo in changeDict.Keys) {
-                foreach (string file in changeDict[repo]) {
+            foreach (SparkleRepoBase repo in change_dict.Keys) {
+                foreach (string file in change_dict[repo]) {
                     FileActivityTask task = MacActivityTask (
                         repo,
                         new FileSystemEventArgs(WatcherChangeTypes.Changed, file, "unknown")

--- a/SparkleShare/Mac/SparkleMacWatcher.cs
+++ b/SparkleShare/Mac/SparkleMacWatcher.cs
@@ -151,19 +151,19 @@ namespace SparkleShare {
 
             var handler = Changed;
             if (handler != null) {
-                List<string> filteredPaths = new List<string> ();
+                List<string> filtered_paths = new List<string> ();
                 foreach (var path in paths) {
                     if (path.Length > BasePath.Length) {
                         var t = path.Substring (BasePath.Length);
                         t = t.Trim ("/".ToCharArray ());
 
                         if (!string.IsNullOrWhiteSpace (t))
-                            filteredPaths.Add(t);
+                            filtered_paths.Add(t);
                     }
                 }
 
-                if(filteredPaths.Count > 0)
-                    handler (filteredPaths);
+                if(filtered_paths.Count > 0)
+                    handler (filtered_paths);
             }
 
             GC.KeepAlive (this);

--- a/SparkleShare/SparkleControllerBase.cs
+++ b/SparkleShare/SparkleControllerBase.cs
@@ -30,32 +30,32 @@ namespace SparkleShare {
         public SparkleRepoBase [] Repositories {
             get {
                 lock (this.repo_lock)
-                    return this.sortedRepositories.GetRange (0, this.sortedRepositories.Count).ToArray ();
+                    return this.sorted_repositories.GetRange (0, this.sorted_repositories.Count).ToArray ();
             }
         }
 
         private void AddRepository(SparkleRepoBase repo)
         {
             lock (this.repo_lock) {
-                sortedRepositories.Add (repo);
-                repositoryDict.Add (repo.Name, repo);
-                sortedRepositories.Sort ((x, y) => string.Compare (x.Name, y.Name));
+                sorted_repositories.Add (repo);
+                repository_dict.Add (repo.Name, repo);
+                sorted_repositories.Sort ((x, y) => string.Compare (x.Name, y.Name));
             }
         }
 
         private void RemoveRepository(SparkleRepoBase repo)
         {
             lock (this.repo_lock) {
-                sortedRepositories.Remove (repo);
-                repositoryDict.Remove (repo.Name);
+                sorted_repositories.Remove (repo);
+                repository_dict.Remove (repo.Name);
             }
         }
 
         public SparkleRepoBase GetRepositoryByName(string name)
         {
             lock (this.repo_lock) {
-                if(repositoryDict.ContainsKey(name))
-                    return repositoryDict [name];
+                if(repository_dict.ContainsKey(name))
+                    return repository_dict [name];
 
                 return null;
             }
@@ -181,8 +181,8 @@ namespace SparkleShare {
         private FileSystemWatcher watcher;
         private Object repo_lock = new Object ();
         private Object check_repos_lock = new Object ();
-        private List<SparkleRepoBase> sortedRepositories = new List<SparkleRepoBase> ();
-        private Dictionary<string, SparkleRepoBase> repositoryDict = new Dictionary<string, SparkleRepoBase> ();
+        private List<SparkleRepoBase> sorted_repositories = new List<SparkleRepoBase> ();
+        private Dictionary<string, SparkleRepoBase> repository_dict = new Dictionary<string, SparkleRepoBase> ();
         private bool lost_folders_path = false;
 
 
@@ -498,7 +498,7 @@ namespace SparkleShare {
 
         private void RemoveRepository (string folder_path)
         {
-            foreach (SparkleRepoBase repo in this.sortedRepositories) {
+            foreach (SparkleRepoBase repo in this.sorted_repositories) {
                 if (repo.LocalPath.Equals (folder_path)) {
                     RemoveRepository (repo);
                     repo.Dispose ();


### PR DESCRIPTION
Hi,

this is a proposed fix for the named issue. The whole point is that we have to process the complete list of paths handed over from the OSX notification. Doing this does take care of the old problem (see old FIXME comment) where you had to pass the changes to all repositories. This is no longer neccessary.

Pls take a close look over this, but this should do it.

I would like to propose 2 further changes for the future
- change the API of RepoBase and pass a list of changes to it rather than calling the MacActivityTask multple
- introduce Rx - this change would be less than half the size :-)

Regards
