### PR TITLE
Replace underscores with spaces only if they are in the middle of a word

### DIFF
--- a/SparkleLib/SparkleExtensions.cs
+++ b/SparkleLib/SparkleExtensions.cs
@@ -106,5 +106,21 @@ namespace SparkleLib {
                 return string.Format ("{0} months ago", Math.Ceiling ((double) day_diff / 31));
             }
         }
+
+
+        public static string ReplaceUnderscoreWithSpace (this string s)
+        {
+            int len = s.Length, lead = 0, trail = 0;
+            for (int i = 0; i < len && s[i] == '_'; i++, lead++)
+                ; // nop
+            for (int i = len - 1; i >= lead && s[i] == '_'; i--, trail++)
+                ; // nop
+            if (lead == 0 && trail == 0)
+                return s.Replace("_", " "); // fast code path
+            else
+                return s.Substring (0, lead) +
+                       s.Substring (lead, len - lead - trail).Replace ("_", " ") +
+                       s.Substring (len - trail, trail);
+        }
     }
 }

--- a/SparkleShare/SparkleControllerBase.cs
+++ b/SparkleShare/SparkleControllerBase.cs
@@ -686,7 +686,7 @@ namespace SparkleShare {
                 canonical_name = canonical_name.Replace (".git", "");
             
             canonical_name = canonical_name.Replace ("-crypto", "");
-            canonical_name = canonical_name.Replace ("_", " ");
+            canonical_name = canonical_name.ReplaceUnderscoreWithSpace ();
             canonical_name = canonical_name.Replace ("%20", " ");
             
             bool target_folder_exists = Directory.Exists (

--- a/SparkleShare/SparkleSetupController.cs
+++ b/SparkleShare/SparkleSetupController.cs
@@ -332,7 +332,7 @@ namespace SparkleShare {
                 SyncingFolder = remote_path.Substring (0, remote_path.Length - 4);
 
 			SyncingFolder         = SyncingFolder.Replace ("-crypto", "");
-			SyncingFolder         = SyncingFolder.Replace ("_", " ");
+			SyncingFolder         = SyncingFolder.ReplaceUnderscoreWithSpace ();
             ProgressBarPercentage = 1.0;
 
             ChangePageEvent (PageType.Syncing, null);
@@ -428,7 +428,7 @@ namespace SparkleShare {
                 SyncingFolder = PendingInvite.RemotePath.Substring (0, PendingInvite.RemotePath.Length - 4);
 
 			SyncingFolder   = SyncingFolder.Replace ("-crypto", "");
-			SyncingFolder   = SyncingFolder.Replace ("_", " ");
+			SyncingFolder   = SyncingFolder.ReplaceUnderscoreWithSpace ();
             PreviousAddress = PendingInvite.Address;
             PreviousPath    = PendingInvite.RemotePath;
 
@@ -556,7 +556,7 @@ namespace SparkleShare {
         public void ShowFilesClicked ()
         {
             string folder_name = Path.GetFileName (PreviousPath);
-            folder_name        = folder_name.Replace ("_", " ");
+            folder_name        = folder_name.ReplaceUnderscoreWithSpace ();
 
             if (PreviousPath.EndsWith ("-crypto"))
                 folder_name = folder_name.Replace ("-crypto", "");


### PR DESCRIPTION
This will fix a corner case in which a repository name starts or ends
with underscores.  For example, a repository with a name '_' will be
cloned as ' ' (space only) without this fix.
