### PR TITLE
Fix packaging for automated build script.

### DIFF
--- a/SparkleShare/Mac/packReleaseDist.sh
+++ b/SparkleShare/Mac/packReleaseDist.sh
@@ -6,11 +6,19 @@ export projectFolder=$(dirname $0)
 
 echo packing ${bundle} for release without Mono framework dependency
 
-export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/Library/Frameworks/Mono.framework/Versions/Current/lib/pkgconfig
+export MONO_PATH=`readlink /Library/Frameworks/Mono.framework/Versions/Current`
+export PKG_CONFIG_PATH=/usr/lib/pkgconfig:${MONO_PATH}/lib/pkgconfig
 export AS="as -arch i386"
 export CC="cc -arch i386 -lobjc -liconv -framework Foundation"
 export PATH=/usr/local/bin:/opt/local/bin:/Library/Frameworks/Mono.framework/Versions/Current/bin:/usr/bin:/bin
 
 cd ${bundle}/Contents/MonoBundle/
-mkbundle --static --deps -o ../MacOS/SparkleShare  SparkleShare.exe SparkleLib.dll MonoMac.dll SparkleLib.Git.dll
+
+# add / fix dependency libMonoPosixHelper
+cp ${MONO_PATH}/lib/libMonoPosixHelper.dylib ../MacOS/
+sed -i .bak 's/libMonoPosixHelper.dylib/@executable_path\/libMonoPosixHelper.dylib/' ./config
+
+# merge all Assemblies into one Mac binary
+mkbundle --static --deps --config ./config  -o ../MacOS/SparkleShare SparkleShare.exe SparkleLib.dll MonoMac.dll SparkleLib.Git.dll
 rm *.dll *.exe
+


### PR DESCRIPTION
there was a bug in my packaging script which causes native posix calls to fail
( from what I know we use them only in initial setup).

this fix takes care of packaging and referring the library libMonoPosixHelper.dylib properly