### PR TITLE
Update SparkleBubbles.cs: Change behavior on NotificationClosed #1669

### DIFF
--- a/SparkleShare/Linux/SparkleBubbles.cs
+++ b/SparkleShare/Linux/SparkleBubbles.cs
@@ -52,11 +52,6 @@ namespace SparkleShare {
 				else
 					notification.IconName = "folder-sparkleshare";
 
-				notification.Closed += delegate (object o, EventArgs args) {
-					if ((args as CloseArgs).Reason == CloseReason.User)
-						Controller.BubbleClicked ();
-				};
-
 				try {
 					notification.Show ();
 


### PR DESCRIPTION
This simply removes the delegate on NotificationClosed by user. #1669

Need to implement a separate solution to deal with raise requests by user when the bubble is actually clicked.
