### PR TITLE
Corrected msysGit link

### DIFF
--- a/SparkleShare/Windows/README.md
+++ b/SparkleShare/Windows/README.md
@@ -6,7 +6,7 @@ You can choose to build SparkleShare from source or to run the Windows installer
 
 Install version 4.0 of the [.NET Framework](http://www.microsoft.com/download/en/details.aspx?id=17851) if you haven't already.
 
-Install [msysGit](http://msysgit.github.io/) and copy the contents of the install folder
+Install [msysGit](https://github.com/msysgit/msysgit/releases) and copy the contents of the install folder
 (`C:\Program Files (x86)\Git` by default) to `C:\path\to\SparkleShare-sources\bin\msysgit\` (create the "bin"-folder in the SparkleShare source directory).
 
 Open a command prompt and execute the following:


### PR DESCRIPTION
Old [msysGit](http://msysgit.github.io/) link redirects to Git 2.x now, and there is issue to run SparkleShare with it. SparkleShare works fine with [Git 1.x](https://github.com/msysgit/msysgit/releases)
"Git for Windows 1.x was retired on August 18th, 2015, superseded by Git for Windows 2.x": https://github.com/msysgit/msysgit