### PR TITLE
Update Mac README.md for location change in sln file

### DIFF
--- a/SparkleShare/Mac/README.md
+++ b/SparkleShare/Mac/README.md
@@ -33,9 +33,10 @@ There are three build configurations available:
 
 To build any of these configurations,
 
-* open `./SparkleShare/Mac/SparkleShare.sln`
+* open `./SparkleShare.sln` in Xamarin Studio
+* select the SparkleShare.Mac project in the Solution view
 * select the required configuration
-* select `Build`, then `"Build SparkleShare"` from the menu
+* select `Build`, then `"Build SparkleShare.Mac"` from the menu
 
 To build SparkleShare from a command line (e.g. for using a CI system), use this command:
 


### PR DESCRIPTION
The sln file is no longer in the SparkleShare/Mac directory. I updated the Xamarin instructions to reflect this. The CLI instructions may be out of date too but I haven't tried them.