### PR TITLE
force using sha256 key derivation in openssl prior to v1.1.0

### DIFF
--- a/Sparkles/Git/GitFetcher.cs
+++ b/Sparkles/Git/GitFetcher.cs
@@ -234,10 +234,10 @@ namespace Sparkles.Git {
             var git_config_required = new GitCommand (TargetFolder, "config filter.encryption.required true");
 
             var git_config_smudge = new GitCommand (TargetFolder, "config filter.encryption.smudge " +
-                string.Format ("\"openssl enc -d -aes-256-cbc -base64 -S {0} -pass file:{1}\"", password_salt, password_file));
+                string.Format ("\"openssl enc -d -aes-256-cbc -base64 -S {0} -pass file:{1} -md md5\"", password_salt, password_file));
 
             var git_config_clean = new GitCommand (TargetFolder, "config filter.encryption.clean " +
-                string.Format ("\"openssl enc -e -aes-256-cbc -base64 -S {0} -pass file:{1}\"", password_salt, password_file));
+                string.Format ("\"openssl enc -e -aes-256-cbc -base64 -S {0} -pass file:{1} -md md5\"", password_salt, password_file));
 
             git_config_required.StartAndWaitForExit ();
             git_config_smudge.StartAndWaitForExit ();
@@ -263,7 +263,7 @@ namespace Sparkles.Git {
                     return false;
             }
 
-            string args = string.Format ("enc -d -aes-256-cbc -base64 -S {0} -pass pass:{1} -in \"{2}\"",
+            string args = string.Format ("enc -d -aes-256-cbc -base64 -S {0} -pass pass:{1} -in \"{2}\" -md md5",
                 password_salt, password.SHA256 (password_salt), password_check_file_path);
 
             var process = new Command ("openssl", args);

--- a/Sparkles/Git/GitFetcher.cs
+++ b/Sparkles/Git/GitFetcher.cs
@@ -234,10 +234,10 @@ namespace Sparkles.Git {
             var git_config_required = new GitCommand (TargetFolder, "config filter.encryption.required true");
 
             var git_config_smudge = new GitCommand (TargetFolder, "config filter.encryption.smudge " +
-                string.Format ("\"openssl enc -d -aes-256-cbc -base64 -S {0} -pass file:{1} -md md5\"", password_salt, password_file));
+                string.Format ("\"openssl enc -d -aes-256-cbc -base64 -S {0} -pass file:{1} -md sha256\"", password_salt, password_file));
 
             var git_config_clean = new GitCommand (TargetFolder, "config filter.encryption.clean " +
-                string.Format ("\"openssl enc -e -aes-256-cbc -base64 -S {0} -pass file:{1} -md md5\"", password_salt, password_file));
+                string.Format ("\"openssl enc -e -aes-256-cbc -base64 -S {0} -pass file:{1} -md sha256\"", password_salt, password_file));
 
             git_config_required.StartAndWaitForExit ();
             git_config_smudge.StartAndWaitForExit ();
@@ -263,7 +263,7 @@ namespace Sparkles.Git {
                     return false;
             }
 
-            string args = string.Format ("enc -d -aes-256-cbc -base64 -S {0} -pass pass:{1} -in \"{2}\" -md md5",
+            string args = string.Format ("enc -d -aes-256-cbc -base64 -S {0} -pass pass:{1} -in \"{2}\" -md sha256",
                 password_salt, password.SHA256 (password_salt), password_check_file_path);
 
             var process = new Command ("openssl", args);


### PR DESCRIPTION
See https://stackoverflow.com/questions/39637388/encryption-decryption-doesnt-work-well-between-two-different-openssl-versions/39641378#39641378 - Openssl changed their default digest algorithm from md5 to sha256 for the key derivation from password beginning with v1.1.0 (which, security wise, is a good thing!), but that creates compatibility issues if the version of openssl that encrypted a file is using a different digest than the version of openssl that decrypts files.

This PR forces always using sha256. This is a breaking change:

- encrypted sparkleshare repos created with both openssl version < 1.1.0 and prior versions of sparkleshare to this patch will fail to decrypt.

In general, openssl based encryption/decryption is less secure than e.g. GPG based ones, especially if the input password has low-entropy. See for instance this: http://stackoverflow.com/a/28248800

Relates to #1738 