### PR TITLE
sparkles: Lazy Configuration Singleton on app startup

### DIFF
--- a/SparkleShare/Common/BaseController.cs
+++ b/SparkleShare/Common/BaseController.cs
@@ -194,18 +194,9 @@ namespace SparkleShare {
         bool lost_folders_path = false;
         
         
-        public BaseController ()
+        public BaseController (Configuration config)
         {
-            string app_data_path = Environment.GetFolderPath (Environment.SpecialFolder.ApplicationData);
-
-            if (InstallationInfo.OperatingSystem != OS.Windows && InstallationInfo.OperatingSystem != OS.Mac)
-                app_data_path = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), ".config");
-
-            string config_path = Path.Combine (app_data_path, "org.sparkleshare.SparkleShare");
-            
-            Config = new Configuration (config_path, "projects.xml");
-            Configuration.DefaultConfiguration = Config;
-
+            Config = config;
             FoldersPath = Config.FoldersPath;
         }
         

--- a/SparkleShare/Common/SparkleShare.cs
+++ b/SparkleShare/Common/SparkleShare.cs
@@ -62,7 +62,7 @@ namespace SparkleShare {
 
             AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
 
-            Controller = new Controller ();
+            Controller = new Controller (Configuration.DefaultConfiguration);
             Controller.Initialize ();
 
             UI = new UserInterface ();

--- a/SparkleShare/Linux/Controller.cs
+++ b/SparkleShare/Linux/Controller.cs
@@ -28,7 +28,8 @@ namespace SparkleShare {
 
     public class Controller : BaseController {
 
-        public Controller ()
+        public Controller (Configuration config)
+            : base (config)
         {
         }
 

--- a/SparkleShare/Mac/Controller.cs
+++ b/SparkleShare/Mac/Controller.cs
@@ -39,7 +39,8 @@ namespace SparkleShare {
         }
 
         
-        public Controller ()
+        public Controller (Configuration config)
+            : base (config)
         {
             NSApplication.Init ();
 

--- a/SparkleShare/Windows/UserInterface/Controller.cs
+++ b/SparkleShare/Windows/UserInterface/Controller.cs
@@ -31,7 +31,8 @@ namespace SparkleShare {
 
     public class Controller : BaseController {
 
-        public Controller ()
+        public Controller (Configuration config)
+            : base (config)
         {
         }
 

--- a/Sparkles/Configuration.cs
+++ b/Sparkles/Configuration.cs
@@ -24,7 +24,18 @@ namespace Sparkles {
 
     public class Configuration : XmlDocument {
 
-        public static Configuration DefaultConfiguration;
+        private static Lazy<Configuration> ConfigLazy = new Lazy<Configuration> (() => {
+            string app_data_path = Environment.GetFolderPath (Environment.SpecialFolder.ApplicationData);
+
+            if (InstallationInfo.OperatingSystem != OS.Windows && InstallationInfo.OperatingSystem != OS.Mac)
+                app_data_path = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), ".config");
+
+            string config_path = Path.Combine (app_data_path, "org.sparkleshare.SparkleShare");
+            
+            return new Configuration (config_path, "projects.xml");
+        });
+        
+        public static Configuration DefaultConfiguration { get { return ConfigLazy.Value; } }
         public static bool DebugMode = true;
 
         public readonly string DirectoryPath;


### PR DESCRIPTION
Pulled from #1572 which is a bit of a mess now...

Builds a singleton for the default configuration on app start.

There's no benefit to using the `Lazy<T>` other than having access to `Lazy.Value`