### PR TITLE
Fix/linux main loop

### DIFF
--- a/SparkleShare/Linux/UserInterface.cs
+++ b/SparkleShare/Linux/UserInterface.cs
@@ -16,6 +16,7 @@
 
 
 using System;
+using System.Reflection;
 
 using Gtk;
 using Sparkles;
@@ -68,17 +69,18 @@ namespace SparkleShare
 
         public void Run (string [] args)
         {
-            // FIXME: Hack to cover API differences between Ubuntu and latest GNOME
-            if (InstallationInfo.OperatingSystem == OS.Ubuntu) {
-                #if HAVE_APP_INDICATOR
-                (application as GLib.Application).Run (0, null);
-                #endif
+            MethodInfo run_method = typeof (GLib.Application).GetMethod ("Run");
+            ParameterInfo [] run_parameters = run_method.GetParameters ();
+
+            // Use the right Run method arguments depending on the installed GTK bindings
+            if (run_parameters [0].ParameterType == typeof (System.Int32) &&
+                run_parameters [1].ParameterType == typeof (System.String)) {
+
+                run_method.Invoke ((application as GLib.Application), new object [] { 0, null });
+
             } else {
-                #if HAVE_APP_INDICATOR
-                #else
-				(application as GLib.Application).Run ("org.sparkleshare.SparkleShare", new string [0]);
-                #endif
-			}
+                run_method.Invoke ((application as GLib.Application), new object [] { "org.sparkleshare.SparkleShare", new string [0] });
+            }
         }
 
 

--- a/SparkleShare/Linux/UserInterface.cs
+++ b/SparkleShare/Linux/UserInterface.cs
@@ -43,6 +43,9 @@ namespace SparkleShare
 
         public UserInterface ()
         {
+            string gtk_version = string.Format ("{0}.{1}.{2}", Global.MajorVersion, Global.MinorVersion, Global.MicroVersion);
+            Logger.LogInfo ("Environment", "GTK+ " + gtk_version);
+
             application = new Application ("org.sparkleshare.SparkleShare", GLib.ApplicationFlags.None);
 
             application.Register (null);


### PR DESCRIPTION
This removes the hack for using the right GLib.Application.Run method. This often didn't work at all, as not just Ubuntu is able to use older versions of gtk-sharp (like in #1791 and others). Now it detects the right method properly using System.Reflection at runtime. 