### PR TITLE
Fix/xdg-open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.sln.cache
 *.user
 *.resources
+Makecache
 Makefile.in
 Makefile
 intltool-*

--- a/SparkleShare/Linux/About.cs
+++ b/SparkleShare/Linux/About.cs
@@ -103,7 +103,7 @@ namespace SparkleShare {
                 Xalign = 0, Xpad = 0
             };
 
-            if (InstallationInfo.Directory.StartsWith ("/app", StringComparison.InvariantCulture))
+            if (InstallationInfo.IsFlatpak)
                 version.Text += " (Flatpak)";
 
             updates = new Label ("Checking for updates…") {

--- a/SparkleShare/Linux/Controller.cs
+++ b/SparkleShare/Linux/Controller.cs
@@ -98,7 +98,10 @@ namespace SparkleShare {
 
         public override void OpenFile (string path)
         {
-            Global.ShowUri (Gdk.Screen.Default, path);
+            if (InstallationInfo.IsFlatpak)
+                Global.ShowUri (Gdk.Screen.Default, path);
+            else
+                new Command ("xdg-open", string.Format ("\"{0}\"", path)).Start ();
         }
 
 

--- a/SparkleShare/Linux/EventLog.cs
+++ b/SparkleShare/Linux/EventLog.cs
@@ -230,6 +230,7 @@ namespace SparkleShare {
                     return false;
                 }
 
+                #pragma warning disable 0612
                 string uri = (decision as NavigationPolicyDecision).Request.Uri;
 
                 if (uri.Equals ("file:///")) {

--- a/SparkleShare/Linux/UserInterface.cs
+++ b/SparkleShare/Linux/UserInterface.cs
@@ -120,3 +120,4 @@ namespace SparkleShare
         }
     }
 }
+

--- a/Sparkles/InstallationInfo.cs
+++ b/Sparkles/InstallationInfo.cs
@@ -95,5 +95,12 @@ namespace Sparkles {
                 return version.Substring (0, version.Length - 2);
             }
         }
+
+
+        public static bool IsFlatpak {
+            get {
+                return Directory.StartsWith ("/app", StringComparison.InvariantCulture);
+            }
+        }
     }
 }


### PR DESCRIPTION
This fixes #1800. This brings back the xdg-open command to handle opening of files and folders when not running in a flatpak.  The `Gtk.ShowUri()` is crashing on Fedora 27 (and possibly others) but is needed in the flatpak because of the portal support.