### PR TITLE
Set exec directory manually when in a flatpak

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Under the hood SparkleShare uses the version control system [Git](https://git-sc
 
 Here are instructions to build SparkleShare on [Linux distributions](SparkleShare/Linux/README.md), [macOS](SparkleShare/Mac/README.md), and [Windows](SparkleShare/Windows/README.md).
 
+Note: on some Linux distributions you'll need the TopIcons extension for GNOME Shell to show the SparkleShare status icon.
+
 [![Build Status](https://travis-ci.org/hbons/SparkleShare.svg?branch=master)](https://travis-ci.org/hbons/SparkleShare)
 [![Join the chat at https://gitter.im/hbons/SparkleShare](https://badges.gitter.im/hbons/SparkleShare.svg)](https://gitter.im/hbons/SparkleShare?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/SparkleShare/Linux/Controller.cs
+++ b/SparkleShare/Linux/Controller.cs
@@ -23,6 +23,7 @@ using Gtk;
 using Mono.Unix.Native;
 
 using Sparkles;
+using Sparkles.Git;
 
 namespace SparkleShare {
 
@@ -31,6 +32,8 @@ namespace SparkleShare {
         public Controller (Configuration config)
             : base (config)
         {
+            if (InstallationInfo.IsFlatpak)
+                GitCommand.ExecPath = Path.Combine ("/app", "libexec", "git-core");
         }
 
 

--- a/SparkleShare/Linux/org.sparkleshare.SparkleShare.appdata.xml
+++ b/SparkleShare/Linux/org.sparkleshare.SparkleShare.appdata.xml
@@ -10,6 +10,7 @@
     <description>
         <p>SparkleShare is a file sharing and collaboration app. It works just like Dropbox, and you can run it on your own server.</p>
         <p>SparkleShare is based on the popular version control system Git. It even supports the popular extension Git LFS to deal well with large files. So if you are already using Git repositories in your company, SparkleShare will integrate seamlessly.</p>
+        <p>Note: on some Linux distributions you'll need the TopIcons extension for GNOME Shell to show the SparkleShare status icon.</p>
     </description>
 
     <releases>
@@ -51,7 +52,7 @@
             <image type="source" width="1600" height="900">https://github.com/hbons/SparkleShare/blob/master/SparkleShare/Linux/Images/gnome-software-screenshot-3.png?raw=true</image>
         </screenshot>
     </screenshots>
-    
+
     <id type="desktop">org.sparkleshare.SparkleShare.desktop</id>
     <launchable id="desktop-id">org.sparkleshare.SparkleShare.desktop</launchable>
     <provides>


### PR DESCRIPTION
The flatpak now uses dugite-native; a binary distribution of Git optimised for file size (and includes Git LFS). To make this work the exec path must be set manually.