### PR TITLE
fix/event-log

### DIFF
--- a/SparkleShare/Mac/UserInterface/EventLog.cs
+++ b/SparkleShare/Mac/UserInterface/EventLog.cs
@@ -340,10 +340,10 @@ namespace SparkleShare {
             html = html.Replace ("<!-- $a-color -->", "#009ff8");
             html = html.Replace ("<!-- $a-hover-color -->", "#009ff8");
             html = html.Replace ("<!-- $pixmaps-path -->", pixmaps_path);
-            html = html.Replace ("<!-- $document-added-background-image -->", pixmaps_path + "/document-added-12.png");
-            html = html.Replace ("<!-- $document-deleted-background-image -->", pixmaps_path + "/document-deleted-12.png");
-            html = html.Replace ("<!-- $document-edited-background-image -->", pixmaps_path + "/document-edited-12.png");
-            html = html.Replace ("<!-- $document-moved-background-image -->", pixmaps_path + "/document-moved-12.png");
+            html = html.Replace ("<!-- $document-added-background-image -->", pixmaps_path + "/document-added.png");
+            html = html.Replace ("<!-- $document-deleted-background-image -->", pixmaps_path + "/document-deleted.png");
+            html = html.Replace ("<!-- $document-edited-background-image -->", pixmaps_path + "/document-edited.png");
+            html = html.Replace ("<!-- $document-moved-background-image -->", pixmaps_path + "/document-moved.png");
 
             this.web_view = new WebView (new CGRect (0, 0, 481, 579), "", "") {
                 Frame = new CGRect (new CGPoint (0, 0), new CGSize (ContentView.Frame.Width, ContentView.Frame.Height - 39))

--- a/SparkleShare/Mac/git.download
+++ b/SparkleShare/Mac/git.download
@@ -1,1 +1,1 @@
-https://github.com/desktop/dugite-native/releases/download/v2.15.1-rc2/dugite-native-v2.15.1-macOS-56.tar.gz 565765a6ffdbad10da6ec849dd86682fa7ad63254b9e07d951e6cf98bb24cac9
+https://github.com/desktop/dugite-native/releases/download/v2.16.2/dugite-native-v2.16.2-macOS-119.tar.gz 65d608eb16e0e262bae6bd7828b28cf640455e949003fec94c1233e084b9ccde


### PR DESCRIPTION
Fixes missing images in the event log on macOS, git-log parsing for newer versions of Git, and get rid of some magic numbers.