### PR TITLE
Fix/freeze-on-quit

### DIFF
--- a/SparkleShare/Common/BaseController.cs
+++ b/SparkleShare/Common/BaseController.cs
@@ -180,7 +180,10 @@ namespace SparkleShare {
         
         // Copies text to the clipboard
         public abstract void CopyToClipboard (string text);
-        
+
+        // Allows for platform-specific quit and cleanup methods to be called on exit
+        public abstract void PlatformQuit ();
+
         public abstract string EventLogHTML { get; }
         public abstract string DayEntryHTML { get; }
         public abstract string EventEntryHTML { get; }
@@ -715,14 +718,14 @@ namespace SparkleShare {
             int suffix = 2 + Directory.GetDirectories (folder_group_path, folder_name + " (*").Length;
             return string.Format ("{0} ({1})", folder_path, suffix);
         }
-        
-        
-        public virtual void Quit ()
+
+
+        public void Quit ()
         {
             foreach (BaseRepository repo in Repositories)
                 repo.Dispose ();
-            
-            Environment.Exit (0);
+
+            PlatformQuit ();
         }
 
 

--- a/SparkleShare/Linux/Controller.cs
+++ b/SparkleShare/Linux/Controller.cs
@@ -29,8 +29,7 @@ namespace SparkleShare {
 
     public class Controller : BaseController {
 
-        public Controller (Configuration config)
-            : base (config)
+        public Controller (Configuration config) : base (config)
         {
             if (InstallationInfo.IsFlatpak)
                 GitCommand.ExecPath = Path.Combine ("/app", "libexec", "git-core");
@@ -141,6 +140,12 @@ namespace SparkleShare {
             get {
                 return Path.Combine (InstallationInfo.Directory, "presets");
             }
+        }
+
+
+        public override void PlatformQuit ()
+        {
+            Environment.Exit (0);
         }
     }
 }

--- a/SparkleShare/Mac/Controller.cs
+++ b/SparkleShare/Mac/Controller.cs
@@ -224,5 +224,13 @@ namespace SparkleShare {
                 new NSObject ().InvokeOnMainThread (() => code ());
             }
         }
+
+
+        public override void PlatformQuit ()
+        {
+            watcher.Dispose ();
+            NSRunningApplication.CurrentApplication.Terminate ();
+        }
+
     }
 }

--- a/SparkleShare/Mac/Controller.cs
+++ b/SparkleShare/Mac/Controller.cs
@@ -80,16 +80,12 @@ namespace SparkleShare {
 
         public override void SetFolderIcon ()
         {
-            if (Environment.OSVersion.Version.Major >= 14) {
-                NSWorkspace.SharedWorkspace.SetIconforFile (
-                    NSImage.ImageNamed ("sparkleshare-folder-yosemite.icns"),
-                    SparkleShare.Controller.FoldersPath, 0);
+            string folder_icon_name = "sparkleshare-folder.icns";
 
-            } else {
-                NSWorkspace.SharedWorkspace.SetIconforFile (
-                    NSImage.ImageNamed ("sparkleshare-folder.icns"),
-                    SparkleShare.Controller.FoldersPath, 0);
-            }
+            if (Environment.OSVersion.Version.Major >= 14)
+                folder_icon_name = "sparkleshare-folder-yosemite.icns";
+
+            NSWorkspace.SharedWorkspace.SetIconforFile (NSImage.ImageNamed (folder_icon_name), SparkleShare.Controller.FoldersPath, 0);
         }
 
 

--- a/SparkleShare/Mac/UserInterface/UserInterface.cs
+++ b/SparkleShare/Mac/UserInterface/UserInterface.cs
@@ -71,13 +71,7 @@ namespace SparkleShare {
 
 
     public partial class AppDelegate : NSApplicationDelegate {
-     
-        public override void WillTerminate (NSNotification notification)
-        {
-            SparkleShare.Controller.Quit ();
-        }
 
-        
         public override bool ApplicationShouldHandleReopen (NSApplication sender, bool has_visible_windows)
         {
             if (!has_visible_windows)

--- a/Sparkles/BaseRepository.cs
+++ b/Sparkles/BaseRepository.cs
@@ -664,7 +664,7 @@ namespace Sparkles {
 
             // this.listener.Dispose ();
 
-            if (!UseCustomWatcher)
+            if (!UseCustomWatcher && this.watcher != null)
                 this.watcher.Dispose ();
         }
     }


### PR DESCRIPTION
Turns out Environment.Exit doesn't quit the app properly sometimes on macOS and a platform specific method call is needed. Fixes #1796 and #1612.