### PR TITLE
Fill in some gaps in Readme

### DIFF
--- a/SparkleShare/Linux/README.md
+++ b/SparkleShare/Linux/README.md
@@ -34,17 +34,20 @@ sudo dnf install \
   meson \
   notify-sharp3-devel \
   webkitgtk4-devel \
-  webkit2-sharp
+  webkit2-sharp \
+  xsltproc
 ```
 
 
 ### Additional source build requirements
 
+Install mono-complete, [see instructions](https://www.mono-project.com/download/stable/#download-lin-ubuntu)
+
 Install the `soup-sharp` and `webkit2gtk-sharp` bindings from:
 https://github.com/hbons/soup-sharp
 https://github.com/hbons/webkit2gtk-sharp
 
-Both with:
+Both with (clone repo and cd into it):
 
 ```bash
 ./autogen.sh
@@ -53,7 +56,7 @@ sudo make install
 ```
 
 Om Ubuntu, also install the `appindicator-sharp` bindings from:
-https://github.com/hbons/appindicator-sharp
+https://github.com/hbons/appindicator-sharp (this will require `libappindicator3-dev` to be installed with `sudo apt install libappindicator3-dev`)
 
 
 ### Start the build

--- a/SparkleShare/Linux/README.md
+++ b/SparkleShare/Linux/README.md
@@ -21,7 +21,8 @@ sudo apt-get install \
   libnotify3.0-cil-dev \
   libsoup2.4-dev \
   libwebkit2gtk-4.0 \
-  meson
+  meson \
+  xsltproc
 
 # On Fedora 27:
 sudo dnf install \
@@ -34,8 +35,7 @@ sudo dnf install \
   meson \
   notify-sharp3-devel \
   webkitgtk4-devel \
-  webkit2-sharp \
-  xsltproc
+  webkit2-sharp
 ```
 
 


### PR DESCRIPTION
Also during some phase of build process I remember a build tool said I can use either `.net` or `mono`. And I tried installing `.net` using [microsoft instruction](https://www.microsoft.com/net/download/linux-package-manager/ubuntu18-04/runtime-2.0.8) but it still complained mono is missing. So I assume mono is the only possible dependency, I suggest to fix this as well.

Also this code is wrong for just copy-pasting to terminal
```
  curl \ # Run requirement
```
The ending `\` should be in the end, otherwise it is not threaten as newline escape. Here the comment breaks this. But I don't know how to elegantly fix this.