### PR TITLE
Prevent blocking on interactive $EDITOR

### DIFF
--- a/Sparkles/Git/Git.Repository.cs
+++ b/Sparkles/Git/Git.Repository.cs
@@ -434,7 +434,7 @@ namespace Sparkles.Git {
             git = new GitCommand (LocalPath, "config core.ignorecase true");
             git.StartAndWaitForExit ();
 
-            git = new GitCommand (LocalPath, "merge FETCH_HEAD");
+            git = new GitCommand (LocalPath, "merge --no-edit FETCH_HEAD");
             git.StartInfo.RedirectStandardOutput = false;
 
             string error_output = git.StartAndReadStandardError ();


### PR DESCRIPTION
It happens that when merging, git calls out an interactive $EDITOR and
waits for user input. This causes SparkleShare to block as well.

Signed-off-by: Maxime “pep” Buquet <pep@collabora.com>