### PR TITLE
Fix AppStream metadata validation

### DIFF
--- a/SparkleShare/Linux/org.sparkleshare.SparkleShare.appdata.xml
+++ b/SparkleShare/Linux/org.sparkleshare.SparkleShare.appdata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop">
+<component type="desktop-application">
     <name>SparkleShare</name>
     <summary>Magic self hosted Git file sync</summary>
     <developer_name>Hylke Bons</developer_name>
@@ -64,13 +64,13 @@
         </screenshot>
     </screenshots>
 
-    <id type="desktop">org.sparkleshare.SparkleShare.desktop</id>
-    <launchable id="desktop-id">org.sparkleshare.SparkleShare.desktop</launchable>
+    <id>org.sparkleshare.SparkleShare</id>
+    <launchable type="desktop-id">org.sparkleshare.SparkleShare.desktop</launchable>
     <provides>
         <binary>sparkleshare</binary>
     </provides>
     
-    <metadata_licence>CC0-1.0</metadata_licence>
+    <metadata_license>CC0-1.0</metadata_license>
     <update_contact>hi_AT_planetpeanut.uk</update_contact>
 
     <content_rating type="oars-1.0">


### PR DESCRIPTION
This fixes the following warnings and errors detected by `appstreamcli validate org.sparkleshare.SparkleShare.appdata.xml`:
```
E - org.sparkleshare.SparkleShare.appdata.xml:org.sparkleshare.SparkleShare.desktop
    The essential tag 'metadata_license' is missing.

W - org.sparkleshare.SparkleShare.appdata.xml:org.sparkleshare.SparkleShare.desktop:73
    Found invalid tag: 'metadata_licence'. Non-standard tags must be prefixed with 
    "x-".

E - org.sparkleshare.SparkleShare.appdata.xml:org.sparkleshare.SparkleShare.desktop:68
    Unknown type '(null)' for <launchable/> tag.

I - org.sparkleshare.SparkleShare.appdata.xml:org.sparkleshare.SparkleShare.desktop:67
    The id tag for "org.sparkleshare.SparkleShare.desktop" still contains a 'type' 
    property, probably from an old conversion.

E - org.sparkleshare.SparkleShare.appdata.xml:org.sparkleshare.SparkleShare.desktop:68
    'launchable' tag has no 'type' property: org.sparkleshare.SparkleShare.desktop
```