### PR TITLE
Add X-AppStream-Ignore property to autostart file

### DIFF
--- a/SparkleShare/Linux/SparkleShare.Autostart.desktop
+++ b/SparkleShare/Linux/SparkleShare.Autostart.desktop
@@ -5,4 +5,4 @@ Exec=sh -c "type -P sparkleshare &>/dev/null && sparkleshare || flatpak run org.
 Icon=org.sparkleshare.SparkleShare
 Terminal=false
 X-GNOME-Autostart-enabled=true
-
+X-AppStream-Ignore=true


### PR DESCRIPTION
This makes appstream-generator to ignore this desktop entry. Since this enty does not specify an individual application, it should be omitted from processing into the AppStream database.

Without this line, appstream-generator tries to process this file, and shows the following error:
```
SparkleShare.Autostart.desktop
Errors

metainfo-no-summary
Component does not contain a short summary. Ensure that the components metainfo file has a summary tag, or that its .desktop file has a Comment= field set.
More information can be found in the Desktop Entry specification and the MetaInfo specification.
```

Other ways to avoid this error:
- Add `NoDisplay=true` property.
- Move out the file from `/usr/share/applications` directory.

See also: https://github.com/ximion/appstream-generator/blob/78bfe323a272c6c099d7fba90aaa769a6e758124/src/asgen/handlers/desktopparser.d#L122