### PR TITLE
Update of license links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Under the hood SparkleShare uses the version control system [Git](https://git-sc
 
 
 ## Build from source
-`SparkleShare` is Free and Open Source software and licensed under the [GNU GPLv3 or later](legal/License_for_SparkleShare.txt). You are welcome to change and redistribute it under certain conditions. Its library `Sparkles` is licensed under the [GNU LGPLv3 or later](legal/License_for_Sparkles.txt).
+`SparkleShare` is Free and Open Source software and licensed under the [GNU GPLv3 or later](LICENSE.md). You are welcome to change and redistribute it under certain conditions. Its library `Sparkles` is licensed under the [GNU LGPLv3 or later](LICENSE_Sparkles.md).
 
 Here are instructions to build SparkleShare on [Linux distributions](SparkleShare/Linux/README.md), [macOS](SparkleShare/Mac/README.md), and [Windows](SparkleShare/Windows/README.md).
 

--- a/SparkleShare/Common/AboutController.cs
+++ b/SparkleShare/Common/AboutController.cs
@@ -32,7 +32,7 @@ namespace SparkleShare {
         public delegate void UpdateLabelEventDelegate (string text);
 
         public readonly string WebsiteLinkAddress       = "https://www.sparkleshare.org/";
-        public readonly string CreditsLinkAddress       = "https://github.com/hbons/SparkleShare/blob/master/legal/Authors.txt";
+        public readonly string CreditsLinkAddress       = "https://github.com/hbons/SparkleShare/blob/master/.github/AUTHORS.md";
         public readonly string ReportProblemLinkAddress = "https://www.github.com/hbons/SparkleShare/issues";
         public readonly string DebugLogLinkAddress      = "file://" + SparkleShare.Controller.Config.LogFilePath;
 


### PR DESCRIPTION
I saw that links in README aren't working anymore, so updated them with links to the proper files in this repo.
I also saw dead link to authors in code, so I thought I'll update it as well.