### PR TITLE
added LibRAavatar

### DIFF
--- a/.github/AUTHORS.md
+++ b/.github/AUTHORS.md
@@ -20,6 +20,7 @@ Code:
 	Luis Cordova <cordoval@gmail.com>
 	Łukasz Jernaś <deejay1@srem.org>
 	Markus Stoll <post@mstoll.de>
+    Malte Kiefer <malte.kiefer@mailgermania.de>
 	Michael Monreal <michael.monreal@gmail.com>
 	Nick Richards <nick@nickr.org>
 	Oleg Khlystov <pktfag@gmail.com>

--- a/SparkleShare/Common/Avatars.cs
+++ b/SparkleShare/Common/Avatars.cs
@@ -115,9 +115,9 @@ namespace SparkleShare
             // On some systems (mostly Linux) we can't assume the needed certificates are
             // available, so we have to check the certificate's SHA-1 fingerprint manually.
             //
-            // SHA1 fingerprinter obtained from https://www.gravatar.com/ on Oct 16 2015
-            // Set to expire on Oct 14 2018
-            string gravatar_cert_fingerprint = "1264B3F00814C6077D3853238771EE67FB6321C9";
+            // SHA1 fingerprinter obtained from https://www.gravatar.com/ on Feb 14 2020
+            // Set to expire on Sep 05 2020
+            string gravatar_cert_fingerprint = "3011C8954A672A01557E804AFF2F3D006D9BBD7C";
 
             if (!certificate2.Thumbprint.Equals (gravatar_cert_fingerprint)) {
                 Logger.LogInfo ("Avatars", "Invalid certificate for https://www.gravatar.com/");

--- a/SparkleShare/Common/Avatars.cs
+++ b/SparkleShare/Common/Avatars.cs
@@ -71,11 +71,12 @@ namespace SparkleShare
             }
 
             var client = new WebClient ();
+            string url = "";
 
             if (provider == "libravatar")
-                string url =  "https://seccdn.libravatar.org/avatar/" + email.MD5 () + ".png?s=" + size + "&d=404";
+                url =  "https://seccdn.libravatar.org/avatar/" + email.MD5 () + ".png?s=" + size + "&d=404";
             else
-                string url =  "https://secure.gravatar.com/avatar/" + email.MD5 () + ".png?s=" + size + "&d=404";
+                url =  "https://secure.gravatar.com/avatar/" + email.MD5 () + ".png?s=" + size + "&d=404";
 
             try {
                 byte [] buffer = client.DownloadData (url);

--- a/SparkleShare/Common/Avatars.cs
+++ b/SparkleShare/Common/Avatars.cs
@@ -35,9 +35,7 @@ namespace SparkleShare
         public static string GetAvatar (string email, int size, string target_path, string provider)
         {
             #if __MonoCS__
-                if (provider == "libravatar")
-                    ServicePointManager.ServerCertificateValidationCallback = GetlibRavatarValidationCallBack;
-                else
+                if (provider == "gravatar")
                     ServicePointManager.ServerCertificateValidationCallback = GetGravatarValidationCallBack;
             #endif
 
@@ -129,26 +127,6 @@ namespace SparkleShare
 
             if (!certificate2.Thumbprint.Equals (gravatar_cert_fingerprint)) {
                 Logger.LogInfo ("Avatars", "Invalid certificate for https://www.gravatar.com/");
-                return false;
-            }
-
-            return true;
-        }
-
-        private static bool GetlibRavatarValidationCallBack (Object sender,
-            X509Certificate certificate, X509Chain chain, SslPolicyErrors errors)
-        {
-            X509Certificate2 certificate2 = new X509Certificate2 (certificate.GetRawCertData ());
-
-            // On some systems (mostly Linux) we can't assume the needed certificates are
-            // available, so we have to check the certificate's SHA-1 fingerprint manually.
-            //
-            // SHA1 fingerprinter obtained from https://www.libravatar.org/ on Feb 14 2020
-            // Set to expire on Apr 02 2020
-            string libravatar_cert_fingerprint = "CF22357CE83BA551D8F877AEFB89EF3668620AE6";
-
-            if (!certificate2.Thumbprint.Equals (libravatar_cert_fingerprint)) {
-                Logger.LogInfo ("Avatars", "Invalid certificate for https://www.libravatar.org/");
                 return false;
             }
 

--- a/SparkleShare/Common/BaseController.cs
+++ b/SparkleShare/Common/BaseController.cs
@@ -153,18 +153,16 @@ namespace SparkleShare {
             }
         }
 
-
         public string AvatarsProvider {
             get {
                 string avatars_provider_string = Config.GetConfigOption ("avatars_provider");
 
-                if (fetch_avatars_option == null)
+                if (avatars_provider_string == null)
                     return "gravatar";
 
                 return avatars_provider_string;
             }
         }
-
 
         // Path where the plugins are kept
         public abstract string PresetsPath { get; }
@@ -464,10 +462,11 @@ namespace SparkleShare {
 
             repo.NewChangeSet += delegate (ChangeSet change_set) {
                 if (AvatarsEnabled) {
+                    string provider = "gravatar";
+
                     if (AvatarsProvider == "libravatar")
                         provider = AvatarsProvider;
-                    else
-                        provider = "gravatar";
+
 
                     change_set.User.AvatarFilePath = Avatars.GetAvatar (change_set.User.Email, 48, Config.DirectoryPath, provider);
 

--- a/SparkleShare/Common/BaseController.cs
+++ b/SparkleShare/Common/BaseController.cs
@@ -154,6 +154,18 @@ namespace SparkleShare {
         }
 
 
+        public string AvatarsProvider {
+            get {
+                string avatars_provider_string = Config.GetConfigOption ("avatars_provider");
+
+                if (fetch_avatars_option == null)
+                    return "gravatar";
+
+                return avatars_provider_string;
+            }
+        }
+
+
         // Path where the plugins are kept
         public abstract string PresetsPath { get; }
 
@@ -451,8 +463,15 @@ namespace SparkleShare {
             };
 
             repo.NewChangeSet += delegate (ChangeSet change_set) {
-                if (AvatarsEnabled)
-                    change_set.User.AvatarFilePath = Avatars.GetAvatar (change_set.User.Email, 48, Config.DirectoryPath);
+                if (AvatarsEnabled) {
+                    if (AvatarsProvider == "libravatar")
+                        provider = AvatarsProvider;
+                    else
+                        provider = "gravatar";
+
+                    change_set.User.AvatarFilePath = Avatars.GetAvatar (change_set.User.Email, 48, Config.DirectoryPath, provider);
+
+                }
 
                 NotificationRaised (change_set);
             };

--- a/SparkleShare/Common/EventLogController.cs
+++ b/SparkleShare/Common/EventLogController.cs
@@ -598,7 +598,7 @@ namespace SparkleShare {
             if (!SparkleShare.Controller.AvatarsEnabled)
                 return "<!-- $pixmaps-path -->/user-icon-default.png";
 
-            string fetched_avatar = Avatars.GetAvatar (user.Email, 48, SparkleShare.Controller.Config.DirectoryPath);
+            string fetched_avatar = Avatars.GetAvatar (user.Email, 48, SparkleShare.Controller.Config.DirectoryPath, SparkleShare.Controller.AvatarsProvider);
 
             if (!string.IsNullOrEmpty (fetched_avatar))
                 return "file://" + fetched_avatar.Replace ("\\", "/");

--- a/SparkleShare/Common/NoteController.cs
+++ b/SparkleShare/Common/NoteController.cs
@@ -39,8 +39,7 @@ namespace SparkleShare {
             SparkleShare.Controller.ShowNoteWindowEvent += OnNoteWindowEvent;
 
             if (SparkleShare.Controller.AvatarsEnabled && !SparkleShare.Controller.FirstRun)
-                AvatarFilePath = Avatars.GetAvatar (SparkleShare.Controller.CurrentUser.Email,
-                    48, SparkleShare.Controller.Config.DirectoryPath);
+                AvatarFilePath = Avatars.GetAvatar (SparkleShare.Controller.CurrentUser.Email, 48, SparkleShare.Controller.Config.DirectoryPath, SparkleShare.Controller.AvatarsProvider);
         }
 
 

--- a/Sparkles/Configuration.cs
+++ b/Sparkles/Configuration.cs
@@ -2,8 +2,8 @@
 //   Copyright (C) 2010  Hylke Bons <hi@planetpeanut.uk>
 //
 //   This program is free software: you can redistribute it and/or modify
-//   it under the terms of the GNU Lesser General Public License as 
-//   published by the Free Software Foundation, either version 3 of the 
+//   it under the terms of the GNU Lesser General Public License as
+//   published by the Free Software Foundation, either version 3 of the
 //   License, or (at your option) any later version.
 //
 //   This program is distributed in the hope that it will be useful,
@@ -32,10 +32,10 @@ namespace Sparkles {
                 app_data_path = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), ".config");
 
             string config_path = Path.Combine (app_data_path, "org.sparkleshare.SparkleShare");
-            
+
             return new Configuration (config_path, "projects.xml");
         });
-        
+
         public static Configuration DefaultConfiguration { get { return ConfigLazy.Value; } }
         public static bool DebugMode = true;
 
@@ -43,6 +43,7 @@ namespace Sparkles {
         public readonly string FilePath;
         public readonly string TmpPath;
         public readonly string BinPath;
+        public string AvatarProvider;
 
         public readonly string LogFilePath;
 
@@ -51,7 +52,7 @@ namespace Sparkles {
             get {
                 if (InstallationInfo.OperatingSystem == OS.Windows)
                     return Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
-                
+
                 return Environment.GetFolderPath (Environment.SpecialFolder.Personal);
             }
         }
@@ -59,9 +60,9 @@ namespace Sparkles {
 
         public string FoldersPath {
             get {
-                if (GetConfigOption ("folders_path") != null)                      
+                if (GetConfigOption ("folders_path") != null)
                     return GetConfigOption ("folders_path");
-                
+
                 return Path.Combine (HomePath, "SparkleShare");
             }
         }
@@ -336,15 +337,15 @@ namespace Sparkles {
         {
             return SelectSingleNode (string.Format ("/sparkleshare/folder[name=\"{0}\"]", name));
         }
-        
-        
+
+
         string FolderValueByKey (string name, string key)
         {
             XmlNode folder = FolderByName(name);
-            
+
             if ((folder != null) && (folder [key] != null))
                 return folder [key].InnerText;
-            
+
             return null;
         }
 


### PR DESCRIPTION
This pull request adds libravatar as provider for avatars. A new option was developed for this:

```xml
<avatars_provider>libravatar</avatars_provider> // optional: gravatar or libravatar
```

Additionally, the fingerprints have been updated. With libravatar it will be exciting. The certificate is only valid for 90 days.