### PR TITLE
Working build for windows

### DIFF
--- a/SparkleShare/Common/AboutController.cs
+++ b/SparkleShare/Common/AboutController.cs
@@ -61,6 +61,11 @@ namespace SparkleShare {
             UpdateLabelEvent ("Checking for updates…");
             Thread.Sleep (500);
 
+            ServicePointManager.Expect100Continue = true;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+            ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
+
+
             var web_client = new WebClient ();
             var uri = new Uri ("https://www.sparkleshare.org/version");
 

--- a/SparkleShare/Common/AboutController.cs
+++ b/SparkleShare/Common/AboutController.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Net;
 using System.Threading;
+using System.Net.Security;
 
 using Sparkles;
 
@@ -61,10 +62,7 @@ namespace SparkleShare {
             UpdateLabelEvent ("Checking for updates…");
             Thread.Sleep (500);
 
-            ServicePointManager.Expect100Continue = true;
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
-
 
             var web_client = new WebClient ();
             var uri = new Uri ("https://www.sparkleshare.org/version");
@@ -83,5 +81,5 @@ namespace SparkleShare {
                 UpdateLabelEvent ("Couldn’t check for updates\t");
             }
         }
-    }
+	}
 }

--- a/SparkleShare/Windows/README.md
+++ b/SparkleShare/Windows/README.md
@@ -7,10 +7,11 @@ You can choose to build SparkleShare from source or to run the Windows installer
 Install [VisualStudioCommunity](https://visualstudio.microsoft.com/de/vs/community/)
 or install version 4.0 of the [.NET Framework](http://www.microsoft.com/download/en/details.aspx?id=17851) if you haven't already.
 
-To install OpenSSH open a cmd.exe as administration and execute the followind code.
+To install OpenSSH open a cmd.exe as administration and execute the following code.
 
 ```
 powershell -command "Add-WindowsCapability -Online -Name OpenSSH.Client"
+powershell -command "Add-WindowsCapability -Online -Name OpenSSH.Server"
 ```
 
 Download [Git](https://github.com/desktop/dugite-native/releases/download/v2.16.2/dugite-native-v2.16.2-win32-119.tar.gz) and copy the contents to `C:\path\to\SparkleShare-sources\bin\msysgit\` (create the "bin"-folder in the SparkleShare source directory).

--- a/SparkleShare/Windows/README.md
+++ b/SparkleShare/Windows/README.md
@@ -4,10 +4,10 @@ You can choose to build SparkleShare from source or to run the Windows installer
 
 ### Installing build requirements
 
-Install version 4.0 of the [.NET Framework](http://www.microsoft.com/download/en/details.aspx?id=17851) if you haven't already.
+Install [VisualStudioCommunity](https://visualstudio.microsoft.com/de/vs/community/)
+or install version 4.0 of the [.NET Framework](http://www.microsoft.com/download/en/details.aspx?id=17851) if you haven't already.
 
-Install [msysGit](https://github.com/msysgit/msysgit/releases) and copy the contents of the install folder
-(`C:\Program Files (x86)\Git` by default) to `C:\path\to\SparkleShare-sources\bin\msysgit\` (create the "bin"-folder in the SparkleShare source directory).
+Download [Git](https://github.com/desktop/dugite-native/releases/download/v2.16.2/dugite-native-v2.16.2-win32-119.tar.gz) and copy the contents to `C:\path\to\SparkleShare-sources\bin\msysgit\` (create the "bin"-folder in the SparkleShare source directory).
 
 Open a command prompt and execute the following:
 
@@ -21,7 +21,7 @@ build
 
 
 ### Creating a Windows installer
-
+-- broken at the moment --
 To create an installer package, install [WiX 3.7](http://wix.codeplex.com/releases/view/99514), restart Windows and run:
 
 ```
@@ -40,4 +40,3 @@ Remove `My Documents\SparkleShare` and `AppData\Roaming\org.sparkleshare.Sparkle
 ### Uninstalling
 
 You can uninstall SparkleShare through the Windows Control Panel.
-

--- a/SparkleShare/Windows/README.md
+++ b/SparkleShare/Windows/README.md
@@ -7,6 +7,12 @@ You can choose to build SparkleShare from source or to run the Windows installer
 Install [VisualStudioCommunity](https://visualstudio.microsoft.com/de/vs/community/)
 or install version 4.0 of the [.NET Framework](http://www.microsoft.com/download/en/details.aspx?id=17851) if you haven't already.
 
+To install OpenSSH open a cmd.exe as administration and execute the followind code.
+
+```
+powershell -command "Add-WindowsCapability -Online -Name OpenSSH.Client"
+```
+
 Download [Git](https://github.com/desktop/dugite-native/releases/download/v2.16.2/dugite-native-v2.16.2-win32-119.tar.gz) and copy the contents to `C:\path\to\SparkleShare-sources\bin\msysgit\` (create the "bin"-folder in the SparkleShare source directory).
 
 Open a command prompt and execute the following:

--- a/SparkleShare/Windows/UserInterface/Controller.cs
+++ b/SparkleShare/Windows/UserInterface/Controller.cs
@@ -54,7 +54,7 @@ namespace SparkleShare {
 
             Environment.SetEnvironmentVariable ("HOME", Environment.GetFolderPath (Environment.SpecialFolder.UserProfile));
 
-            SSHCommand.SSHPath = Path.Combine (msysgit_path, "usr", "bin");
+            SSHCommand.SSHPath = "";
             SSHFetcher.SSHKeyScan = "ssh-keyscan.exe";
             GitCommand.GitPath = Path.Combine (msysgit_path, "cmd", "git.exe");
 

--- a/SparkleShare/Windows/UserInterface/Controller.cs
+++ b/SparkleShare/Windows/UserInterface/Controller.cs
@@ -56,7 +56,7 @@ namespace SparkleShare {
 
             SSHCommand.SSHPath = Path.Combine (msysgit_path, "usr", "bin");
             SSHFetcher.SSHKeyScan = "ssh-keyscan.exe";
-            GitCommand.GitPath = Path.Combine (msysgit_path, "bin", "git.exe");
+            GitCommand.GitPath = Path.Combine (msysgit_path, "cmd", "git.exe");
 
             base.Initialize ();
         }

--- a/SparkleShare/Windows/UserInterface/Controller.cs
+++ b/SparkleShare/Windows/UserInterface/Controller.cs
@@ -57,7 +57,7 @@ namespace SparkleShare {
             SSHCommand.SSHPath = "";
             SSHFetcher.SSHKeyScan = "ssh-keyscan.exe";
             GitCommand.GitPath = Path.Combine (msysgit_path, "cmd", "git.exe");
-
+            File.Copy(Path.Combine(msysgit_path, "mingw64","libexec","git-core", "git-lfs.exe"),Path.Combine(Config.BinPath, "git-lfs.exe"),true);            
             base.Initialize ();
         }
 
@@ -129,7 +129,7 @@ namespace SparkleShare {
             Shortcut shortcut = new Shortcut ();
             shortcut.Create (shortcut_path, shortcut_target);
         }
-        
+
 
         public override void InstallProtocolHandler ()
         {
@@ -184,7 +184,7 @@ namespace SparkleShare {
         {
             try {
                 Clipboard.SetData (DataFormats.Text, text);
-            
+
             } catch (COMException e) {
                 Logger.LogInfo ("Controller", "Copy to clipboard failed", e);
             }

--- a/SparkleShare/Windows/UserInterface/Controller.cs
+++ b/SparkleShare/Windows/UserInterface/Controller.cs
@@ -55,7 +55,7 @@ namespace SparkleShare {
             Environment.SetEnvironmentVariable ("HOME", Environment.GetFolderPath (Environment.SpecialFolder.UserProfile));
 
             SSHCommand.SSHPath = Path.Combine (msysgit_path, "usr", "bin");
-            SSHFetcher.SSHKeyScan = Path.Combine (msysgit_path, "usr", "bin", "ssh-keyscan.exe");
+            SSHFetcher.SSHKeyScan = "ssh-keyscan.exe";
             GitCommand.GitPath = Path.Combine (msysgit_path, "bin", "git.exe");
 
             base.Initialize ();
@@ -191,7 +191,7 @@ namespace SparkleShare {
         }
 
 
-        public override void Quit ()
+        public override void PlatformQuit ()
         {
             base.Quit ();
         }

--- a/SparkleShare/Windows/build.cmd
+++ b/SparkleShare/Windows/build.cmd
@@ -8,7 +8,7 @@ set wixBinDir=%WIX%\bin
 if not exist ..\..\bin mkdir ..\..\bin
 copy Images\sparkleshare-app.ico ..\..\bin\
 
-%msbuild% /t:Rebuild /p:Configuration=Release /p:Platform="Any CPU" "%~dp0\SparkleShare.sln"
+%msbuild% /t:Rebuild /p:Configuration=Release /p:Platform="Any CPU" "%~dp0\..\..\SparkleShare.sln"
 
 if "%1"=="installer" (
 	if exist "%wixBinDir%" (

--- a/Sparkles/Command.cs
+++ b/Sparkles/Command.cs
@@ -62,7 +62,8 @@ namespace Sparkles {
                 base.Start ();
 
             } catch (Exception e) {
-                Logger.LogInfo ("Cmd", "Couldn't execute command: " + e.Message);
+                Logger.LogInfo ("Cmd", "Couldn't execute command: " 
+                    +StartInfo.FileName+","+ e.Message);
                 Environment.Exit (-1);
             }
         }


### PR DESCRIPTION
After seeing the pull-request of etinin i tried to build the windows version. Because of the binary files you did not accept the pull-request. Therefore i found a workaround to use the Windows 10 openSSH.
I described the setup procedure in the windows readme.md.
I also changed the mysysgit to the same git version as is used in the mac build. 
With these changes the windows version builds and is working.
The installer is not fixed yet. 