### PR TITLE
Fix problem on renaming HEAD file

### DIFF
--- a/Sparkles/Git/Git.Repository.cs
+++ b/Sparkles/Git/Git.Repository.cs
@@ -934,7 +934,12 @@ namespace Sparkles.Git {
                         string HEAD_file_path = Path.Combine (child_path, "HEAD");
 
                         if (File.Exists (HEAD_file_path)) {
-                            File.Move (HEAD_file_path, HEAD_file_path + ".backup");
+                            string HEAD_file_path_backup = Path.Combine (child_path, "HEAD.backup");
+                            if (File.Exists (HEAD_file_path_backup)) {
+                                File.Delete (HEAD_file_path_backup);
+                            }
+
+                            File.Move (HEAD_file_path, HEAD_file_path_backup);
                             Logger.LogInfo ("Git", Name + " | Renamed " + HEAD_file_path);
                         }
 


### PR DESCRIPTION
HEAD file for embedded `.git` folders is renamed to `HEAD.backup`.
But this works only once - if the `.backup` file is already present, we fail and create follow up problems. 
So I remove the `.backup` file first.