### PR TITLE
Bugfixes/mac fix encodingproblems

### DIFF
--- a/SparkleShare/Common/BubblesController.cs
+++ b/SparkleShare/Common/BubblesController.cs
@@ -21,13 +21,20 @@ using Sparkles;
 namespace SparkleShare {
 
     public class BubblesController {
+        private bool fix_utf_encoding;
 
         public event ShowBubbleEventHandler ShowBubbleEvent = delegate { };
         public delegate void ShowBubbleEventHandler (string title, string subtext, string image_path);
 
 
-        public BubblesController ()
+        public BubblesController () : this(true)
         {
+        }
+
+        public BubblesController (bool fix_utf_encoding)
+        {
+            this.fix_utf_encoding = fix_utf_encoding;
+
             SparkleShare.Controller.AlertNotificationRaised += delegate (string title, string message) {
                 ShowBubble (title, message, null);
             };
@@ -40,10 +47,13 @@ namespace SparkleShare {
 
         public void ShowBubble (string title, string subtext, string image_path)
         {
-            byte [] title_bytes   = Encoding.Default.GetBytes (title);
-            byte [] subtext_bytes = Encoding.Default.GetBytes (subtext);
-            title                 = Encoding.UTF8.GetString (title_bytes);
-            subtext               = Encoding.UTF8.GetString (subtext_bytes);
+            if(fix_utf_encoding)
+            {
+                byte [] title_bytes = Encoding.Default.GetBytes (title);
+                byte [] subtext_bytes = Encoding.Default.GetBytes (subtext);
+                title = Encoding.UTF8.GetString (title_bytes);
+                subtext = Encoding.UTF8.GetString (subtext_bytes);
+            }
 
             ShowBubbleEvent (title, subtext, image_path);
         }

--- a/SparkleShare/Common/EventLogController.cs
+++ b/SparkleShare/Common/EventLogController.cs
@@ -53,7 +53,7 @@ namespace SparkleShare {
         private string selected_folder;
         private RevisionInfo restore_revision_info;
         private bool history_view_active;
-
+        private bool fix_utf_encoding;
 
         public bool WindowIsOpen { get; private set; }
 
@@ -144,8 +144,14 @@ namespace SparkleShare {
         }
 
 
-        public EventLogController ()
+        public EventLogController () : this (true)
         {
+        }
+
+        public EventLogController (bool fix_utf_encoding)
+        {
+            this.fix_utf_encoding = fix_utf_encoding;
+
             SparkleShare.Controller.ShowEventLogWindowEvent += delegate {
                 if (!WindowIsOpen) {
                     ContentLoadingEvent ();
@@ -257,8 +263,11 @@ namespace SparkleShare {
                 string folder    = href.Replace ("history://", "").Split ("/".ToCharArray ()) [0];
                 string file_path = href.Replace ("history://" + folder + "/", "");
 
-                byte [] file_path_bytes = Encoding.Default.GetBytes (file_path);
-                file_path               = Encoding.UTF8.GetString (file_path_bytes);
+                if(fix_utf_encoding)
+                {
+                    byte [] file_path_bytes = Encoding.Default.GetBytes (file_path);
+                    file_path = Encoding.UTF8.GetString (file_path_bytes);
+                }
 
                 file_path = Uri.UnescapeDataString (file_path);
 
@@ -536,10 +545,13 @@ namespace SparkleShare {
 
         private string FormatBreadCrumbs (string path_root, string path)
         {
-            byte [] path_root_bytes = Encoding.Default.GetBytes (path_root);
-            byte [] path_bytes      = Encoding.Default.GetBytes (path);
-            path_root               = Encoding.UTF8.GetString (path_root_bytes);
-            path                    = Encoding.UTF8.GetString (path_bytes);
+            if(fix_utf_encoding)
+            {
+                byte [] path_root_bytes = Encoding.Default.GetBytes (path_root);
+                byte [] path_bytes = Encoding.Default.GetBytes (path);
+                path_root = Encoding.UTF8.GetString (path_root_bytes);
+                path = Encoding.UTF8.GetString (path_bytes);
+            }
 
             path_root                = path_root.Replace ("/", Path.DirectorySeparatorChar.ToString ());
             path                     = path.Replace ("/", Path.DirectorySeparatorChar.ToString ());

--- a/SparkleShare/Mac/UserInterface/Bubbles.cs
+++ b/SparkleShare/Mac/UserInterface/Bubbles.cs
@@ -22,7 +22,7 @@ namespace SparkleShare {
     
     public class Bubbles : NSObject {
 
-        public BubblesController Controller = new BubblesController ();
+        public BubblesController Controller = new BubblesController (false);
 
 
         public Bubbles ()

--- a/SparkleShare/Mac/UserInterface/EventLog.cs
+++ b/SparkleShare/Mac/UserInterface/EventLog.cs
@@ -27,7 +27,7 @@ namespace SparkleShare {
 
     public class EventLog : NSWindow {
 
-        public EventLogController Controller = new EventLogController ();
+        public EventLogController Controller = new EventLogController (false);
         public float TitlebarHeight;
 
         WebView web_view;

--- a/Sparkles/Command.cs
+++ b/Sparkles/Command.cs
@@ -41,6 +41,7 @@ namespace Sparkles {
             StartInfo.WorkingDirectory = Path.GetTempPath ();
             StartInfo.CreateNoWindow = true;
             StartInfo.RedirectStandardOutput = true;
+            StartInfo.StandardOutputEncoding = System.Text.Encoding.UTF8;
             StartInfo.RedirectStandardError = true;
             StartInfo.UseShellExecute = false;
 

--- a/Sparkles/Git/Git.Command.cs
+++ b/Sparkles/Git/Git.Command.cs
@@ -99,7 +99,8 @@ namespace Sparkles.Git {
             SetEnvironmentVariable ("PREFIX", "");
             SetEnvironmentVariable ("HOME", "");
 
-            SetEnvironmentVariable ("LANG", "en_US");
+            SetEnvironmentVariable ("LANG", "en_US.UTF8");
+            SetEnvironmentVariable ("LC_ALL", "en_US.UTF8");
         }
 
 

--- a/Sparkles/Git/Git.Repository.cs
+++ b/Sparkles/Git/Git.Repository.cs
@@ -435,6 +435,7 @@ namespace Sparkles.Git {
             git.StartAndWaitForExit ();
 
             git = new GitCommand (LocalPath, "merge --no-edit FETCH_HEAD");
+            git.StartInfo.StandardOutputEncoding = null;
             git.StartInfo.RedirectStandardOutput = false;
 
             string error_output = git.StartAndReadStandardError ();
@@ -616,6 +617,7 @@ namespace Sparkles.Git {
             var git = new GitCommand (LocalPath,
                 "commit --message=\"Conflict resolution\" --author=\"SparkleShare <info@sparkleshare.org>\"");
 
+            git.StartInfo.StandardOutputEncoding = null;
             git.StartInfo.RedirectStandardOutput = false;
             git.StartAndWaitForExit ();
 


### PR DESCRIPTION
See issue #1966 

With current Visual Studio the complete handling of special characters in path/file names was broken.
This fix enforces UTF8 encoding for all git calls and disables the encoding conversion which break things again as Default encoding is ASCII on current Visual Studio 2019 on macOS