### PR TITLE
Mac FileWatcher - reduce load

### DIFF
--- a/SparkleShare/Mac/Watcher.cs
+++ b/SparkleShare/Mac/Watcher.cs
@@ -149,6 +149,10 @@ namespace SparkleShare {
             if (handler != null) {
                 List<string> filtered_paths = new List<string> ();
                 foreach (var path in paths) {
+                    if (path.EndsWith(".git")
+                        || path.Contains ("/.git/"))
+                        continue;
+
                     if (path.Length > BasePath.Length) {
                         var t = path.Substring (BasePath.Length);
                         t = t.Trim ("/".ToCharArray ());


### PR DESCRIPTION
I noticed quite some high load when the Mac version detects changes. As we do get a large amount of notifitions on the .git subfolder which are going to be dropped later in the chain, we can reduce cpu load, if we drop these immediately.