### PR TITLE
Fix crash when pressing show files

### DIFF
--- a/SparkleShare/Common/SetupController.cs
+++ b/SparkleShare/Common/SetupController.cs
@@ -533,7 +533,7 @@ namespace SparkleShare {
 
         public void ShowFilesClicked ()
         {
-            string folder_name = Path.GetFileName (PreviousPath);
+            string folder_name = Path.GetFileNameWithoutExtension (PreviousPath);
             folder_name = folder_name.ReplaceUnderscoreWithSpace ();
 
             SparkleShare.Controller.OpenSparkleShareFolder (folder_name);


### PR DESCRIPTION
Pressing the ShowFiles button in the SetupDialog after cloning a new project kills the application.
The variable ```PreviousPath``` contains the remote path with git extension. The function ```SparkleShare.Controller.OpenSparkleShareFolder (folder_name);``` expects the local name name (without git extension).
When removing the extension for this function call the folder shows up like expected.

