### PR TITLE
Poll for updates when waking up from sleep state (macOS)

### DIFF
--- a/SparkleShare/Mac/Controller.cs
+++ b/SparkleShare/Mac/Controller.cs
@@ -51,6 +51,16 @@ namespace SparkleShare {
                 Path.Combine (GitCommand.ExecPath, "git-lfs"),
                 Path.Combine (Config.BinPath, "git-lfs"),
                 overwite);
+            
+            NSWorkspace.Notifications.ObserveDidWake((object sender, NSNotificationEventArgs e) => {
+                Console.Write ("Detected wake from sleep, checking for updates\n");
+                if (SparkleShare.Controller.RepositoriesLoaded) {
+                    foreach (var repo in SparkleShare.Controller.Repositories) {
+                        repo.SyncDown();
+                        repo.SyncUp();
+                    }
+                }
+            });
         }
 
 


### PR DESCRIPTION
I've ran into the issue a few times that there are changes on the remote but after opening my laptop, I'm not seeing these changes for a few minutes until the polling decides to check again. It seems reasonable to do a check when the laptop lid is opened and this pull request adds just that. 
The same functionality could be added for Linux and Windows I guess but I have no way of testing that at the moment.