### PR TITLE
Fix for issue #1958

### DIFF
--- a/Sparkles/Git/Git.Fetcher.cs
+++ b/Sparkles/Git/Git.Fetcher.cs
@@ -176,6 +176,11 @@ namespace Sparkles.Git {
                 File.WriteAllText (identifier_path, identifier);
                 File.SetAttributes (identifier_path, FileAttributes.Hidden);
 
+                var git_config = new GitCommand(TargetFolder, "config user.name \"SparkleShare\"");
+                git_config.StartAndWaitForExit();
+                git_config = new GitCommand(TargetFolder, "config user.email \"info@sparkleshare.org\"");
+                git_config.StartAndWaitForExit();
+                
                 // We can't do the "commit --all" shortcut because it doesn't add untracked files
                 var git_add    = new GitCommand (TargetFolder, "add .sparkleshare");
                 var git_commit = new GitCommand (TargetFolder,

--- a/Sparkles/Git/Git.Fetcher.cs
+++ b/Sparkles/Git/Git.Fetcher.cs
@@ -176,6 +176,8 @@ namespace Sparkles.Git {
                 File.WriteAllText (identifier_path, identifier);
                 File.SetAttributes (identifier_path, FileAttributes.Hidden);
 
+                // The repo is freshly cloned and no config user.name is set yet, so temporary use SparkleShare
+                // to avoid error 'TELL ME WHO YOU ARE', later on this will be handled in Commit of Git.Repository
                 var git_config = new GitCommand(TargetFolder, "config user.name \"SparkleShare\"");
                 git_config.StartAndWaitForExit();
                 git_config = new GitCommand(TargetFolder, "config user.email \"info@sparkleshare.org\"");


### PR DESCRIPTION
When creating a crypto repo first comit is on master branch and the folowing on the crypto branch.
But git complains at first commit, because the user is not known. `Tell me who you are`
So set user before first commit to SparkleShare, then things work as expected.
Fix for this: https://github.com/hbons/SparkleShare/issues/1958
When using the master brunch this bug is not relevant because next commit fixes things.
Newer versions of git are a bit restrictiver. When git is packaged to SparkleShare this does not happen, but under linux the system git is used and this ist much newer.