### PR TITLE
Updated macOS version names

### DIFF
--- a/SparkleShare/Mac/checkGit.sh
+++ b/SparkleShare/Mac/checkGit.sh
@@ -1,4 +1,4 @@
-#!/bin/sh                                                                                                                                          
+#!/bin/sh
 function abspath()
 {
   case "${1}" in
@@ -31,12 +31,12 @@ set -e
 
 if [[ ! -f ${projectFolder}/${gitName} ]];
 then
-  curl --silent --location ${gitDownload} > ${gitName}
+  curl --silent --location ${gitDownload} > ${projectFolder}/${gitName}
   test -e ${gitName} || { echo "Failed to download git"; exit 1; }
 
   printf "${gitSHA256}  ${gitName}" | shasum --check --algorithm 256
 
 fi
 
-rm git.tar.gz
-ln -s $gitName git.tar.gz
+rm -f git.tar.gz
+ln -s ${projectFolder}/$gitName git.tar.gz

--- a/SparkleShare/Mac/checkGit.sh
+++ b/SparkleShare/Mac/checkGit.sh
@@ -32,11 +32,11 @@ set -e
 if [[ ! -f ${projectFolder}/${gitName} ]];
 then
   curl --silent --location ${gitDownload} > ${projectFolder}/${gitName}
-  test -e ${gitName} || { echo "Failed to download git"; exit 1; }
+  test -e ${projectFolder}/${gitName} || { echo "Failed to download git"; exit 1; }
 
-  printf "${gitSHA256}  ${gitName}" | shasum --check --algorithm 256
+  printf "${gitSHA256}  ${projectFolder}/${gitName}" | shasum --check --algorithm 256
 
 fi
 
-rm -f git.tar.gz
-ln -s ${projectFolder}/$gitName git.tar.gz
+rm -f ${projectFolder}/git.tar.gz
+ln -s ${projectFolder}/$gitName ${projectFolder}/git.tar.gz

--- a/SparkleShare/Mac/postBuild.sh
+++ b/SparkleShare/Mac/postBuild.sh
@@ -12,4 +12,4 @@ ${projectFolder}/checkGit.sh
 rm -rf ${bundle}/Contents/Resources/git
 mkdir ${bundle}/Contents/Resources/git
 tar -x -f ${projectFolder}/git.tar.gz --directory ${bundle}/Contents/Resources/git
-cp -R SparkleShareInviteOpener.app ${bundle}/Contents/Resources
+cp -R ${projectFolder}/SparkleShareInviteOpener.app ${bundle}/Contents/Resources

--- a/SparkleShare/Mac/postBuild.sh
+++ b/SparkleShare/Mac/postBuild.sh
@@ -10,6 +10,6 @@ export PATH=/usr/local/bin:/opt/local/bin:/Library/Frameworks/Mono.framework/Ver
 
 ${projectFolder}/checkGit.sh
 rm -rf ${bundle}/Contents/Resources/git
-mkdir ${bundle}/Contents/Resources/git
+mkdir -p ${bundle}/Contents/Resources/git
 tar -x -f ${projectFolder}/git.tar.gz --directory ${bundle}/Contents/Resources/git
 cp -R ${projectFolder}/SparkleShareInviteOpener.app ${bundle}/Contents/Resources

--- a/Sparkles/InstallationInfo.cs
+++ b/Sparkles/InstallationInfo.cs
@@ -67,25 +67,35 @@ namespace Sparkles {
             get {
                 if (OperatingSystem == OS.macOS) {
                     var uname = new Command ("sw_vers", "-productVersion", write_output: false);
-                    string output = uname.StartAndReadStandardOutput ();
-                    string version = output;
+                    string version = uname.StartAndReadStandardOutput ();
 
-                    // Parse the version number between the periods (e.g. "10.12.1" -> 12)
-                    output = output.Substring (output.IndexOf (".") + 1);
-                    if (output.LastIndexOf (".") != -1) {
-                        output = output.Substring (0, output.LastIndexOf ("."));
-                    }
+                    // 
+                    string[] version_elements= version.Split('.');
+
                     string release = "Unreleased Version";
 
-                    switch (int.Parse (output)) {
-                    case 7: release = "Lion"; break;
-                    case 8: release = "Mountain Lion"; break;
-                    case 9: release = "Mavericks"; break;
-                    case 10: release = "Yosemite"; break;
-                    case 11: release = "El Capitan"; break;
-                    case 12: release = "Sierra"; break;
-                    case 13: release = "High Sierra"; break;
-                    case 14: release = "Mojave"; break;
+                    if ((version_elements.Length) >= 2) {
+                        switch (int.Parse (version_elements [0])) {
+                        case 10:
+                            // Parse the version number between the periods (e.g. "10.12.1" -> 12)
+                            switch (int.Parse (version_elements [0])) {
+                            case 7: release = "Lion"; break;
+                            case 8: release = "Mountain Lion"; break;
+                            case 9: release = "Mavericks"; break;
+                            case 10: release = "Yosemite"; break;
+                            case 11: release = "El Capitan"; break;
+                            case 12: release = "Sierra"; break;
+                            case 13: release = "High Sierra"; break;
+                            case 14: release = "Mojave"; break;
+                            case 15: release = "Catalina"; break;
+                            }
+                            break;
+
+                        case 11:
+                            release = "BigSur"; break;
+                        case 12:
+                            release = "Monterey"; break;
+                        }
                     }
 
                     return string.Format ("{0} ({1})", version, release);


### PR DESCRIPTION
On recent versions of macOS SparkleShare shows unreleased version in the log file.
`Environment | macOS 11.6 (Unreleased Version)`
Here is an update for the version naming. Apple slightly changed the scheme,  
now the first number block is relevant for the name.

There are also two small fixes for the scripts. When first time starting `checkGit.sh` it fails, because there is no `git.tar.gz` to delete and then no link will be generated because the script stops. When starting rm with -f it does not fail in this case and the link will be created.
In `postBuild.sh` and in `checkGit.sh` was missing a `$(projectFolder)` variable, but this is only relevant if starting the script with other path focus than the project starts it.