### PR TITLE
Find ssh commands via locate

### DIFF
--- a/SparkleShare/Common/BaseController.cs
+++ b/SparkleShare/Common/BaseController.cs
@@ -224,6 +224,9 @@ namespace SparkleShare {
             Logger.LogInfo ("Environment", "SparkleShare " + version);
             Logger.LogInfo ("Environment", "Git LFS " + Sparkles.Git.GitCommand.GitLFSVersion);
             Logger.LogInfo ("Environment", "Git " + Sparkles.Git.GitCommand.GitVersion);
+            Logger.LogInfo ("Environment", "SSH " + Sparkles.SSHCommand.SSHVersion);
+            Logger.LogInfo ("Environment", "SSH-KeyGen " + Sparkles.SSHCommand.KeygenVersion);
+            Logger.LogInfo ("Environment", "SSH-KeyScan " + Sparkles.SSHCommand.KeyscanVersion);
             Logger.LogInfo ("Environment", InstallationInfo.OperatingSystem + " " + InstallationInfo.OperatingSystemVersion);
 
             UserAuthenticationInfo = new SSHAuthenticationInfo ();

--- a/Sparkles/Git/Git.Command.cs
+++ b/Sparkles/Git/Git.Command.cs
@@ -221,9 +221,10 @@ namespace Sparkles.Git {
 
         public static string FormatGitSSHCommand (SSHAuthenticationInfo auth_info)
         {
-            return SSHCommandPath + " " +
-                "-i " + auth_info.PrivateKeyFilePath.Replace ("\\", "/").Replace (" ", "\\ ") + " " +
-                "-o UserKnownHostsFile=" + auth_info.KnownHostsFilePath.Replace ("\\", "/").Replace (" ", "\\ ") + " " +
+            return "\""+SSHCommandPath + "\" " +
+                "-i \"" + auth_info.PrivateKeyFilePath.Replace ("\\", "/").Replace (" ", "\\ ") + "\" " +
+                "-o UserKnownHostsFile=\"" + auth_info.KnownHostsFilePath.Replace ("\\", "/").Replace (" ", "\\ ") + "\" " +
+
                 "-o IdentitiesOnly=yes" + " " + // Don't fall back to other keys on the system
                 "-o PasswordAuthentication=no" + " " + // Don't hang on possible password prompts
                 "-F /dev/null"; // Ignore the system's SSH config file

--- a/Sparkles/Git/Git.Repository.cs
+++ b/Sparkles/Git/Git.Repository.cs
@@ -79,7 +79,7 @@ namespace Sparkles.Git {
             git_config = new GitCommand (LocalPath, "config remote.origin.url \"" + RemoteUrl + "\"");
             git_config.StartAndWaitForExit ();
 
-            git_config = new GitCommand (LocalPath, "config core.sshCommand " + GitCommand.FormatGitSSHCommand (auth_info));
+            git_config = new GitCommand (LocalPath, "config core.sshCommand \"" + GitCommand.FormatGitSSHCommand (auth_info).Replace("\"", "\\\"") + "\"");
             git_config.StartAndWaitForExit();
 
             PrepareGitLFS ();

--- a/Sparkles/SSHAuthenticationInfo.cs
+++ b/Sparkles/SSHAuthenticationInfo.cs
@@ -100,7 +100,7 @@ namespace Sparkles {
                 "-C \"" + computer_name + " (SparkleShare)\" " + // Key comment
                 "-f \"" + key_file_name + "\"";
 
-            var ssh_keygen = new SSHCommand ("ssh-keygen", arguments);
+            var ssh_keygen = new SSHCommand (SSHCommand.SSHKeyGenCommandPath, arguments);
             ssh_keygen.StartInfo.WorkingDirectory = Path;
             ssh_keygen.StartAndWaitForExit ();
 

--- a/Sparkles/SSHFetcher.cs
+++ b/Sparkles/SSHFetcher.cs
@@ -23,9 +23,6 @@ namespace Sparkles {
     
     public abstract class SSHFetcher : BaseFetcher {
 
-        public static string SSHKeyScan = "ssh-keyscan";
-
-
         protected SSHFetcher (SparkleFetcherInfo info) : base (info)
         {
         }
@@ -68,7 +65,7 @@ namespace Sparkles {
         string FetchHostKey ()
         {
             Logger.LogInfo ("Auth", string.Format ("Fetching host key for {0}", RemoteUrl.Host));
-            var ssh_keyscan = new Command (SSHKeyScan, string.Format ("-t rsa -p 22 {0}", RemoteUrl.Host));
+            var ssh_keyscan = new SSHCommand (SSHCommand.SSHKeyScanCommandPath, string.Format ("-t rsa -p 22 {0}", RemoteUrl.Host));
 
             if (RemoteUrl.Port > 0)
                 ssh_keyscan.StartInfo.Arguments = string.Format ("-t rsa -p {0} {1}", RemoteUrl.Port, RemoteUrl.Host);


### PR DESCRIPTION
SparkleShare uses several comandline tools to provide functionality. While working on the windows version i saw that ssh, ssh-keygen and ssh-keyscan was hard coded and sparkleshare expects that these are in the path. This is not always given.
I extended the SSHCommand.cs to da the location of all ssh related commands. The additional calls in BaseController.cs checks for existance of the shs commands. As ssh-keyscan and ssh-keygen does not provide a version info they are called to check if they are there.
The enquating is changed from ' to ", because this is the platform independent way.