### PR TITLE
Define security protocol

### DIFF
--- a/SparkleShare/Common/AboutController.cs
+++ b/SparkleShare/Common/AboutController.cs
@@ -61,13 +61,15 @@ namespace SparkleShare {
             UpdateLabelEvent ("Checking for updates…");
             Thread.Sleep (500);
 
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             var web_client = new WebClient ();
             var uri = new Uri ("https://www.sparkleshare.org/version");
 
             try {
                 string latest_version = web_client.DownloadString (uri);
                 latest_version = latest_version.Trim ();
-            
+
                 if (new Version (latest_version) > new Version (RunningVersion))
                     UpdateLabelEvent ("An update (version " + latest_version + ") is available!");
                 else

--- a/SparkleShare/Common/AboutController.cs
+++ b/SparkleShare/Common/AboutController.cs
@@ -69,7 +69,7 @@ namespace SparkleShare {
             try {
                 string latest_version = web_client.DownloadString (uri);
                 latest_version = latest_version.Trim ();
-
+            
                 if (new Version (latest_version) > new Version (RunningVersion))
                     UpdateLabelEvent ("An update (version " + latest_version + ") is available!");
                 else


### PR DESCRIPTION
When running under windows dotnet the security protocol has to be defined for the version check. Linux and maOS could handle it also before, but defining it does no harm.
This is the last pull request of the tear the windows pull request to smaller chuncks serie...
Then tere will only stay windows related changes. All commen changes are in the last pull requests.

